### PR TITLE
Fix panic if config dir inexistant: create_dir_all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "duralumin"
+name = "dura"
 version = "0.1.0"
 dependencies = [
  "git2",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,20 +1,18 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::fs::{File, create_dir_all, OpenOptions};
+use std::fs::{create_dir_all, File, OpenOptions};
 use std::io;
+use std::path::{Path, PathBuf};
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WatchConfig {
-}
+pub struct WatchConfig {}
 
 impl WatchConfig {
     pub fn new() -> Self {
-        Self {
-        }
+        Self {}
     }
 }
 
@@ -56,6 +54,8 @@ impl Config {
 
     pub fn save(&self) {
         let path = Self::default_path();
+        path.clone().parent().map(create_dir_all);
+
         let file = OpenOptions::new()
             .write(true)
             .create(true)
@@ -71,4 +71,3 @@ impl Config {
         self.repos.insert(path, cfg);
     }
 }
-


### PR DESCRIPTION
Add a call to _create_dir_all_ to fix panic if the config parent dir doesn't exist.
+ change to cargo.lock => outdated, project renamed from **duralumin** to **dura** ?

Nb: sorry, rustfmt applied on commit