### PR TITLE
Add fish integration

### DIFF
--- a/scripts/dura.fish
+++ b/scripts/dura.fish
@@ -1,0 +1,38 @@
+set script (realpath (status --current-filename))
+if pgrep -fq $script
+    exit 0
+end
+
+function tempfile
+    if command_exists mktemp
+        command mktemp
+    else
+        command tempfile
+    end
+end
+
+set MONITOR_TEMP_FILE (tempfile)
+set MONITOR_PID_FILE (tempfile)
+
+function duraMonitor
+    pkill -P (cat $MONITOR_PID_FILE) 2>/dev/null
+    pkill (cat $MONITOR_PID_FILE) 2>/dev/null
+
+    echo '
+    set repos (cat ~/.config/dura/config.json | jq -rc \'.repos | keys | join("§")\' 2>/dev/null)
+    set pollingSeconds (cat ~/.config/dura/config.json | jq -r ".pollingSeconds // 5")
+
+    fswatch -e .git -0 -l $pollingSeconds -r (string split "§" -- $repos) | while read -l -z path
+        cd $path 2>/dev/null || cd (dirname $path) && cd (git rev-parse --show-toplevel) && dura capture
+    end
+    ' >$MONITOR_TEMP_FILE
+
+    fish $MONITOR_TEMP_FILE &
+    jobs -p >$MONITOR_PID_FILE
+end
+
+
+duraMonitor
+fswatch -0 -l 3 ~/.config/dura/config.json | while read -l -z path
+    duraMonitor
+end


### PR DESCRIPTION
Before doing any changes to the Rust code, I wanted to get an idea of how we want these scripts to work.

The `dura.fish` shell script can:
1. Read `repos` and `pollingSeconds` from `config.json`
2. Start a repo watcher in the background using those settings
3. Watch for changes in `config.json` and restart the repo watcher on any change
4. Ensure only one instance of the script is running (helpful if you want to add it in `conf.d` as a script that runs on each shell startup)

If we settle on a fish shell script, I can then try to convert that to POSIX bash/zsh and add some basic `dura install` command.