### PR TITLE
Replace which with command -v

### DIFF
--- a/scripts/dura.fish
+++ b/scripts/dura.fish
@@ -4,7 +4,7 @@ if pgrep -f $script >/dev/null 2>/dev/null
 end
 
 function tempfile
-    if which mktemp >/dev/null 2>/dev/null
+    if command -v mktemp >/dev/null 2>/dev/null
         command mktemp
     else
         command tempfile


### PR DESCRIPTION
`command -v` is a better choice here than `which` because many
operating systems have a `which` that doesn't set an exit status,
causing this to return true incorrectly. Additinally, which launches
an external process, so `command -v` will be cheaper and POSIX
complient.

See
https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script
for more details