### PR TITLE
Make test use tmpdir for saving config

### DIFF
--- a/tests/end_to_end_test.rs
+++ b/tests/end_to_end_test.rs
@@ -20,13 +20,13 @@ fn start_serve() {
 
 #[test]
 fn start_serve_with_null_pid_in_config() {
+    let mut dura = util::dura::Dura::new();
     let mut cfg = Config::empty();
     cfg.pid = None;
-    cfg.save();
+    dura.save_config(&cfg);
 
-    let mut dura = util::dura::Dura::new();
     assert_eq!(None, dura.pid(true));
-    assert_eq!(None, dura.get_config());
+    assert_ne!(None, dura.get_config());
 
     dura.start_async(&["serve"], true);
     dura.wait();


### PR DESCRIPTION
Currently, the `start_serve_with_null_pid_in_config` actually writes to `~/.config/dura` instead of the temporary directory, like the other tests.

This patch makes it use a temporary directory for the config, like other tests. It also reverses an assert, because previously the test wouldn't load the config file at all (since it tried to load from the temporary directory, and not from home).