### PR TITLE
CLI Improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ async fn main() {
                 .long_flag("serve")
                 .about("Starts the worker that listens for file changes. If another process is already running, this will do it's best to terminate the other process.")
                 .arg(
-                    Arg::new("logfile")
+                    arg!(--logfile)
                     .required(false)
                     .help("Sets custom logfile. Default is logging to stdout")
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,11 +88,11 @@ async fn main() {
                 println!("{}", oid);
             }
         }
-        Some(("serve", m)) => {
+        Some(("serve", arg_matches)) => {
             let env_filter =
                 EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
-            match m.value_of("logfile") {
+            match arg_matches.value_of("logfile") {
                 Some(logfile) => {
                     let file = logfile.to_string();
                     Registry::default()
@@ -124,20 +124,20 @@ async fn main() {
             tracing::info!(pid = std::process::id());
             poller::start().await;
         }
-        Some(("watch", m)) => {
-            let dir = Path::new(m.value_of("directory").unwrap());
+        Some(("watch", arg_matches)) => {
+            let dir = Path::new(arg_matches.value_of("directory").unwrap());
 
-            let include = m
+            let include = arg_matches
                 .values_of("include")
                 .unwrap_or(Values::default())
                 .map(|s| s.to_string())
                 .collect::<Vec<String>>();
-            let exclude = m
+            let exclude = arg_matches
                 .values_of("exclude")
                 .unwrap_or(Values::default())
                 .map(|s| s.to_string())
                 .collect::<Vec<String>>();
-            let max_depth = m
+            let max_depth = arg_matches
                 .value_of("maxdepth")
                 .unwrap_or("255")
                 .parse::<u8>()
@@ -151,8 +151,8 @@ async fn main() {
 
             watch_dir(dir, watch_config);
         }
-        Some(("unwatch", m)) => {
-            let dir = Path::new(m.value_of("directory").unwrap());
+        Some(("unwatch", arg_matches)) => {
+            let dir = Path::new(arg_matches.value_of("directory").unwrap());
             unwatch_dir(dir)
         }
         Some(("kill", _)) => {


### PR DESCRIPTION
Leading on from the conversion to Clap, this makes the CLI improvements discussed in #51. These are as follows:

- The program will still default to the CWD, but you can now optionally specify a directory for watch/unwatch/snapshot using a positional arg
- Include, exclude and maxdepth flags have been added when watching a directory to control the recursive behaviour. Multiple comma-separated include/exclude paths can be specified.
- The `logfile` arg for serve has been changed from positional to a flag

```
dura watch --help                                                           dura-watch 
Add the current working directory as a repository to watch.

USAGE:
    dura {watch, --watch, -W} [OPTIONS] [directory]

ARGS:
    <directory>    The directory to watch. Defaults to current directory [default:
                   /home/jake/Programming/dura]

OPTIONS:
    -d, --maxdepth <maxdepth>    Determines the depth to recurse into when scanning directories
                                 [default: 255]
    -e, --exclude <exclude>      Excludes specific directories relative to the watch directory
    -h, --help                   Print help information
    -i, --include <include>      Overrides excludes by re-including specific directories relative to
                                 the watch directory.

```

Example usage:
```
dura watch ~/Programming --exclude some-repo,third-party --include third-party/dura --mathdepth 3