### PR TITLE
Refactor: Extract GitRepoIter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ clap = "3.0.5"
 git2 = "0.13"
 home = "0.5.3"
 tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 chrono = "0.4"
 tracing = { version = "0.1.5"}

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,9 +5,11 @@ use std::{env, io};
 
 use serde::{Deserialize, Serialize};
 
+use crate::git_repo_iter::GitRepoIter;
+
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct WatchConfig {
     pub include: Vec<String>,
     pub exclude: Vec<String>,
@@ -114,5 +116,9 @@ impl Config {
             Some(_) => println!("Stopped watching {}", path),
             None => println!("{} is not being watched", path),
         }
+    }
+
+    pub fn git_repos(&self) -> GitRepoIter {
+        GitRepoIter::new(self)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fs::{create_dir_all, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::{env, io};
+use std::rc::Rc;
 
 use serde::{Deserialize, Serialize};
 
@@ -35,7 +36,7 @@ impl Default for WatchConfig {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Config {
     pub pid: Option<u32>,
-    pub repos: HashMap<String, WatchConfig>,
+    pub repos: HashMap<String, Rc<WatchConfig>>,
 }
 
 impl Config {
@@ -106,7 +107,7 @@ impl Config {
         if self.repos.contains_key(&path) {
             println!("{} is already being watched", path)
         } else {
-            self.repos.insert(path.clone(), cfg);
+            self.repos.insert(path.clone(), Rc::new(cfg));
             println!("Started watching {}", path)
         }
     }

--- a/src/git_repo_iter.rs
+++ b/src/git_repo_iter.rs
@@ -1,0 +1,121 @@
+use std::fs;
+use std::path::{PathBuf, Path};
+use std::collections::hash_map;
+
+use crate::config::{Config, WatchConfig};
+use crate::snapshots;
+
+/// Iterator over all Git repos covered by a config.
+///
+/// The process is naturally recursive, traversing a directory structure, which made it a poor fit
+/// for a more typical filter/map chain.
+///
+/// Function recursion is used in a few cases:
+///  1. Errors: If we get an I/O error, we'll call self.next() again
+///  2. Empty iterator: If we get to the end of a sub-iterator, pop & start from the top
+///
+pub struct GitRepoIter<'a> {
+    config_iter: hash_map::Iter<'a, String, WatchConfig>,
+    /// A stack, because we can't use recursion with an iterator (at least not between elements)
+    sub_iter: Vec<(PathBuf, WatchConfig, fs::ReadDir)>,
+}
+
+impl<'a> GitRepoIter<'a> {
+    pub fn new(config: &'a Config) -> Self {
+        Self { config_iter: config.repos.iter(), sub_iter: Vec::new() }
+    }
+}
+
+impl<'a> Iterator for GitRepoIter<'a> {
+    type Item = PathBuf;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // pop
+        // 
+        // Use pop here to manage the lifetime of the iterator. If we used last/peek, we would
+        // borrow a shared reference, which precludes us from borrowing as mutable when we want to
+        // use the iterator. But that means we have to return it to the vec.
+        match self.sub_iter.pop() {
+            Some((base_path, watch_config, mut dir_iter)) => {
+                let mut next_next: Option<(PathBuf, WatchConfig, fs::ReadDir)> = None;
+                let mut ret_val = None;
+                let max_depth: usize = watch_config.max_depth.into();
+                if let Some(Ok(entry)) = dir_iter.next() {
+                    let child_path = entry.path();
+                    if is_valid_directory(base_path.as_path(), child_path.as_path(), &watch_config) {
+                        if snapshots::is_repo(child_path.as_path()) {
+                            ret_val = Some(child_path);
+                        } else if self.sub_iter.len() < max_depth {
+                            if let Ok(child_dir_iter) = fs::read_dir(child_path.as_path()) {
+                                next_next = Some((base_path.clone(), watch_config.clone(), child_dir_iter))
+                            }
+                        }
+                    }
+                    // un-pop
+                    if ret_val.is_none() {
+                        self.sub_iter.push((base_path, watch_config, dir_iter));
+                    }
+                }
+                if let Some(tuple) = next_next {
+                    // directory recursion
+                    self.sub_iter.push(tuple);
+                }
+                if let Some(ret) = ret_val {
+                    Some(ret)
+                } else {
+                    self.next()  // recursive call
+                }
+            }
+            None => {
+                // Finished dir, queue up next hashmap pair
+                match self.config_iter.next() {
+                    Some((base_path, watch_config)) => {
+                        let path = PathBuf::from(base_path);
+                        let dir_iter_opt = path.parent()
+                            .and_then(|p| fs::read_dir(p).ok());
+                        if let Some(dir_iter) = dir_iter_opt {
+                            // clone because we're going from more global to less global scope
+                            self.sub_iter.push((path, watch_config.clone(), dir_iter));
+                        }
+                        self.next()  // recursive call
+                    }
+                    // The end. The real end. This is it.
+                    None => None
+                }
+            }
+        }
+    }
+}
+
+/// Checks the provided `child_path` is a directory.
+/// If either `includes` or `excludes` are set,
+/// checks whether the path is included/excluded respectively.
+fn is_valid_directory(base_path: &Path, child_path: &Path, value: &WatchConfig) -> bool {
+    if !child_path.is_dir() {
+        return false;
+    }
+
+    if !child_path.starts_with(base_path) {
+        return false;
+    }
+
+    let includes = &value.include;
+    let excludes = &value.exclude;
+
+    let mut include = true;
+
+    if !excludes.is_empty() {
+        include = !excludes
+            .iter()
+            .any(|exclude| child_path.starts_with(base_path.join(exclude)));
+    }
+
+    if !include && !includes.is_empty() {
+        include = includes
+            .iter()
+            .any(|include| base_path.join(include).starts_with(child_path));
+    }
+
+    include
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod git_repo_iter;
 pub mod log;
 pub mod logger;
 pub mod poller;

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::Path;
 use std::process;
 use std::time::Instant;
@@ -6,88 +5,40 @@ use std::time::Instant;
 use tokio::time;
 use tracing::{error, info};
 
-use crate::config::{Config, WatchConfig};
+use crate::config::Config;
 use crate::log::Operation;
 use crate::snapshots;
 
-/// Checks the provided `child_path` is a directory.
-/// If either `includes` or `excludes` are set,
-/// checks whether the path is included/excluded respectively.
-fn is_valid_directory(base_path: &Path, child_path: &Path, value: &WatchConfig) -> bool {
-    if !child_path.is_dir() {
-        return false;
-    }
-
-    let includes = &value.include;
-    let excludes = &value.exclude;
-
-    let mut include = true;
-
-    if !excludes.is_empty() {
-        include = !excludes
-            .iter()
-            .any(|exclude| child_path.starts_with(base_path.join(exclude)));
-    }
-
-    if !include && !includes.is_empty() {
-        include = includes
-            .iter()
-            .any(|include| base_path.join(include).starts_with(child_path));
-    }
-
-    include
-}
 
 /// If the directory is a repo, attempts to create a snapshot.
 /// Otherwise, recurses into each child directory.
 #[tracing::instrument]
-fn process_directory(base_path: &Path, current_path: &Path, value: &WatchConfig, depth: u8) {
-    if snapshots::is_repo(current_path) {
-        let mut op: Option<snapshots::CaptureStatus> = None;
-        let mut error: Option<String> = None;
-        let start_time = Instant::now();
+fn process_directory(current_path: &Path) {
+    let mut op: Option<snapshots::CaptureStatus> = None;
+    let mut error: Option<String> = None;
+    let start_time = Instant::now();
 
-        match snapshots::capture(current_path) {
-            Ok(Some(status)) => op = Some(status),
-            Ok(None) => (),
-            Err(err) => {
-                error = Some(format!("{}", err));
-            }
+    match snapshots::capture(current_path) {
+        Ok(Some(status)) => op = Some(status),
+        Ok(None) => (),
+        Err(err) => {
+            error = Some(format!("{}", err));
         }
+    }
 
-        let latency = (Instant::now() - start_time).as_secs_f32();
-        let repo = current_path
-            .to_str()
-            .unwrap_or("<invalid path>")
-            .to_string();
-        let operation = Operation::Snapshot {
-            repo,
-            op,
-            error,
-            latency,
-        };
-        if operation.should_log() {
-            info!(operation = %serde_json::to_string(&operation).unwrap(),"info_operation")
-        }
-    } else {
-        if depth >= value.max_depth {
-            return;
-        }
-
-        if let Ok(paths) = fs::read_dir(current_path) {
-            paths
-                .filter_map(|entry| {
-                    if let Ok(entry) = entry {
-                        let child_path = entry.path();
-                        if is_valid_directory(base_path, &child_path, value) {
-                            return Some(child_path);
-                        }
-                    }
-
-                    None
-                })
-                .for_each(|path| process_directory(base_path, path.as_path(), value, depth + 1));
-        }
+    let latency = (Instant::now() - start_time).as_secs_f32();
+    let repo = current_path
+        .to_str()
+        .unwrap_or("<invalid path>")
+        .to_string();
+    let operation = Operation::Snapshot {
+        repo,
+        op,
+        error,
+        latency,
+    };
+    if operation.should_log() {
+        info!(operation = %serde_json::to_string(&operation).unwrap(),"info_operation")
     }
 }
 
@@ -102,9 +53,8 @@ fn do_task() {
         process::exit(1);
     }
 
-    for (key, value) in config.repos {
-        let path = Path::new(key.as_str());
-        process_directory(path, path, &value, 0);
+    for repo in config.git_repos() {
+        process_directory(repo.as_path());
     }
 }
 

--- a/tests/snapshots_test.rs
+++ b/tests/snapshots_test.rs
@@ -20,7 +20,7 @@ fn change_single_file() {
 #[test]
 fn no_changes() {
     let tmp = tempfile::tempdir().unwrap();
-    let mut repo = util::git_repo::GitRepo::new(tmp.path().to_path_buf());
+    let repo = util::git_repo::GitRepo::new(tmp.path().to_path_buf());
     repo.init();
     repo.write_file("foo.txt");
     repo.commit_all();

--- a/tests/startup_test.rs
+++ b/tests/startup_test.rs
@@ -78,3 +78,4 @@ fn start_serve_with_invalid_json() {
     assert_ne!(None, cfg);
     assert_eq!(dura.pid(true), cfg.unwrap().pid);
 }
+

--- a/tests/util/git_repo.rs
+++ b/tests/util/git_repo.rs
@@ -53,6 +53,7 @@ impl GitRepo {
     }
 
     pub fn init(&self) {
+        fs::create_dir_all(self.dir.as_path()).unwrap();
         let _ = self.git(&["init"]);
         let _ = self.git(&["checkout", "-b", "master"]);
     }

--- a/tests/watch_test.rs
+++ b/tests/watch_test.rs
@@ -1,0 +1,32 @@
+mod util;
+
+use crate::util::dura::Dura;
+use crate::util::git_repo::GitRepo;
+
+#[test]
+fn watch_repo() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = GitRepo::new(tmp.path().to_path_buf());
+    repo.init();
+    
+    let dura = Dura::new();
+    dura.run_in_dir(&["watch"], tmp.path());
+    assert_eq!(dura.git_repos(), vec![tmp.path().canonicalize().unwrap()]);
+}
+
+#[test]
+fn watch_1_dir_with_2_repos() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo1 = GitRepo::new(tmp.path().join("repo1"));
+    repo1.init();
+    let repo2 = GitRepo::new(tmp.path().join("repo2"));
+    repo2.init();
+    
+    let dura = Dura::new();
+    dura.run_in_dir(&["watch"], tmp.path());
+    assert_eq!(dura.git_repos(), vec![
+        repo1.dir.canonicalize().unwrap(),
+        repo2.dir.canonicalize().unwrap(),
+    ]);
+}
+

--- a/tests/watch_test.rs
+++ b/tests/watch_test.rs
@@ -30,3 +30,14 @@ fn watch_1_dir_with_2_repos() {
     ]);
 }
 
+#[test]
+fn watch_dir_with_repo_nested_3_folders_deep() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = GitRepo::new(tmp.path().join("a/b/c"));
+    repo.init();
+    
+    let dura = Dura::new();
+    dura.run_in_dir(&["watch"], tmp.path());
+    assert_eq!(dura.git_repos(), vec![repo.dir.canonicalize().unwrap()]);
+}
+


### PR DESCRIPTION
`poller::process_directory` became recursive in #49. This function did 2 things:

1. Recursively list out all Git repos
2. Process them

This change separates these two responsibilities. This gives us a lot of flexibility, like the ability to see query the watched directories. We used to just look directly at the Config object, but since it was refactored we lost that ability. This gains that ability back.

@JakeStanger take a peek