### PR TITLE
Split config file and runtime DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,17 +84,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dura"
 version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "dirs",
  "git2",
- "home",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -116,6 +137,17 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -146,15 +178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "home"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -458,6 +481,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +699,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,12 @@ edition = "2021"
 [dependencies]
 clap = "3.0.5"
 git2 = "0.13"
-home = "0.5.3"
+dirs = "4.0.0"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 chrono = "0.4"
+toml = "0.5.8"
 tracing = { version = "0.1.5"}
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
-use std::fs::{create_dir_all, File, OpenOptions};
+use std::fs::{create_dir_all, File};
 use std::path::{Path, PathBuf};
-use std::{env, io};
+use std::{env, fs};
+use std::io::{BufReader, Read};
 use std::rc::Rc;
 
 use serde::{Deserialize, Serialize};
@@ -35,37 +36,35 @@ impl Default for WatchConfig {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Config {
-    pub pid: Option<u32>,
     pub repos: HashMap<String, Rc<WatchConfig>>,
 }
 
 impl Config {
     pub fn empty() -> Self {
         Self {
-            pid: None,
             repos: HashMap::new(),
         }
     }
 
     pub fn default_path() -> PathBuf {
-        Self::get_dura_home().join("config.json")
+        Self::get_dura_config_home().join("config.toml")
     }
 
     /// Location of all config & database files. By default this is ~/.config/dura but can be
-    /// overridden by setting DURA_HOME environment variable.
-    fn get_dura_home() -> PathBuf {
+    /// overridden by setting DURA_CONFIG_HOME environment variable.
+    fn get_dura_config_home() -> PathBuf {
         // The environment variable lets us run tests independently, but I'm sure someone will come
         // up with another reason to use it.
-        if let Ok(env_var) = env::var("DURA_HOME") {
+        if let Ok(env_var) = env::var("DURA_CONFIG_HOME") {
             if !env_var.is_empty() {
                 return env_var.into();
             }
         }
 
-        home::home_dir()
-        .expect("Could not find your home directory. The default is ~/.config/dura but it can also \
-                be controlled by setting the DURA_HOME environment variable.")
-        .join(".config/dura")
+        dirs::config_dir()
+            .expect("Could not find your config directory. The default is ~/.config/dura but it can also \
+                be controlled by setting the DURA_CONFIG_HOME environment variable.")
+            .join("dura")
     }
 
     /// Load Config from default path
@@ -74,12 +73,16 @@ impl Config {
     }
 
     pub fn load_file(path: &Path) -> Result<Self> {
-        let reader = io::BufReader::new(File::open(path)?);
-        let res = serde_json::from_reader(reader)?;
+        let mut reader = BufReader::new(File::open(path)?);
+
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer)?;
+
+        let res = toml::from_slice(buffer.as_slice())?;
         Ok(res)
     }
 
-    /// Save config to disk in ~/.config/dura/config.json
+    /// Save config to disk in ~/.config/dura/config.toml
     pub fn save(&self) {
         self.save_to_path(Self::default_path().as_path())
     }
@@ -92,15 +95,7 @@ impl Config {
     pub fn save_to_path(&self, path: &Path) {
         Self::create_dir(path);
 
-        let file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path)
-            .unwrap();
-
-        let writer = io::BufWriter::new(file);
-        serde_json::to_writer(writer, self).unwrap();
+        fs::write(path, toml::to_string(self).unwrap()).unwrap();
     }
 
     pub fn set_watch(&mut self, path: String, cfg: WatchConfig) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 use std::fs::{create_dir_all, File};
-use std::path::{Path, PathBuf};
-use std::{env, fs};
 use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
+use std::{env, fs};
 
 use serde::{Deserialize, Serialize};
 
@@ -99,18 +99,24 @@ impl Config {
     }
 
     pub fn set_watch(&mut self, path: String, cfg: WatchConfig) {
-        if self.repos.contains_key(&path) {
-            println!("{} is already being watched", path)
+        let abs_path = fs::canonicalize(path).expect("The provided path is not a directory");
+        let abs_path = abs_path.to_str().unwrap();
+
+        if self.repos.contains_key(abs_path) {
+            println!("{} is already being watched", abs_path)
         } else {
-            self.repos.insert(path.clone(), Rc::new(cfg));
-            println!("Started watching {}", path)
+            self.repos.insert(abs_path.to_string(), Rc::new(cfg));
+            println!("Started watching {}", abs_path)
         }
     }
 
     pub fn set_unwatch(&mut self, path: String) {
-        match self.repos.remove(&path) {
-            Some(_) => println!("Stopped watching {}", path),
-            None => println!("{} is not being watched", path),
+        let abs_path = fs::canonicalize(path).expect("The provided path is not a directory");
+        let abs_path = abs_path.to_str().unwrap().to_string();
+
+        match self.repos.remove(&abs_path) {
+            Some(_) => println!("Stopped watching {}", abs_path),
+            None => println!("{} is not being watched", abs_path),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs::{create_dir_all, File};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
@@ -36,13 +36,13 @@ impl Default for WatchConfig {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Config {
-    pub repos: HashMap<String, Rc<WatchConfig>>,
+    pub repos: BTreeMap<String, Rc<WatchConfig>>,
 }
 
 impl Config {
     pub fn empty() -> Self {
         Self {
-            repos: HashMap::new(),
+            repos: BTreeMap::new(),
         }
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,7 +1,7 @@
-use std::fs::{create_dir_all, File, OpenOptions};
-use std::io::{Result};
+use std::fs::{create_dir_all, File};
+use std::io::Result;
 use std::path::{Path, PathBuf};
-use std::{env, io};
+use std::{env, fs, io};
 
 use serde::{Deserialize, Serialize};
 
@@ -59,15 +59,6 @@ impl RuntimeLock {
     /// Used by tests to save to a temp dir
     pub fn save_to_path(&self, path: &Path) {
         Self::create_dir(path);
-
-        let file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path)
-            .unwrap();
-
-        let writer = io::BufWriter::new(file);
-        serde_json::to_writer(writer, self).unwrap();
+        fs::write(path, serde_json::to_string(self).unwrap()).unwrap()
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -6,11 +6,11 @@ use std::{env, io};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
-pub struct RuntimeDatabase {
+pub struct RuntimeLock {
     pub pid: Option<u32>,
 }
 
-impl RuntimeDatabase {
+impl RuntimeLock {
     pub fn empty() -> Self {
         Self { pid: None }
     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,0 +1,73 @@
+use std::fs::{create_dir_all, File, OpenOptions};
+use std::io::{Result};
+use std::path::{Path, PathBuf};
+use std::{env, io};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeDatabase {
+    pub pid: Option<u32>,
+}
+
+impl RuntimeDatabase {
+    pub fn empty() -> Self {
+        Self { pid: None }
+    }
+
+    pub fn default_path() -> PathBuf {
+        Self::get_dura_cache_home().join("runtime.db")
+    }
+
+    /// Location of all config & database files. By default this is ~/.cache/dura but can be
+    /// overridden by setting DURA_CACHE_HOME environment variable.
+    fn get_dura_cache_home() -> PathBuf {
+        // The environment variable lets us run tests independently, but I'm sure someone will come
+        // up with another reason to use it.
+        if let Ok(env_var) = env::var("DURA_CACHE_HOME") {
+            if !env_var.is_empty() {
+                return env_var.into();
+            }
+        }
+
+        dirs::cache_dir()
+            .expect("Could not find your cache directory. The default is ~/.cache/dura but it can also \
+                be controlled by setting the DURA_CACHE_HOME environment variable.")
+            .join("dura")
+    }
+
+    /// Load Config from default path
+    pub fn load() -> Self {
+        Self::load_file(Self::default_path().as_path()).unwrap_or_else(|_| Self::empty())
+    }
+
+    pub fn load_file(path: &Path) -> Result<Self> {
+        let reader = io::BufReader::new(File::open(path)?);
+        let res = serde_json::from_reader(reader)?;
+        Ok(res)
+    }
+
+    /// Save config to disk in ~/.cache/dura/runtime.db
+    pub fn save(&self) {
+        self.save_to_path(Self::default_path().as_path())
+    }
+
+    pub fn create_dir(path: &Path) {
+        path.parent().map(|dir| create_dir_all(dir).unwrap());
+    }
+
+    /// Used by tests to save to a temp dir
+    pub fn save_to_path(&self, path: &Path) {
+        Self::create_dir(path);
+
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)
+            .unwrap();
+
+        let writer = io::BufWriter::new(file);
+        serde_json::to_writer(writer, self).unwrap();
+    }
+}

--- a/src/git_repo_iter.rs
+++ b/src/git_repo_iter.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::{PathBuf, Path};
-use std::collections::hash_map;
+use std::collections::{btree_map};
 use std::rc::Rc;
 
 use crate::config::{Config, WatchConfig};
@@ -26,7 +26,7 @@ enum CallState {
 ///  2. Empty iterator: If we get to the end of a sub-iterator, pop & start from the top
 ///
 pub struct GitRepoIter<'a> {
-    config_iter: hash_map::Iter<'a, String, Rc<WatchConfig>>,
+    config_iter: btree_map::Iter<'a, String, Rc<WatchConfig>>,
     /// A stack, because we can't use recursion with an iterator (at least not between elements)
     sub_iter: Vec<(Rc<PathBuf>, Rc<WatchConfig>, fs::ReadDir)>,
 }
@@ -38,7 +38,7 @@ impl<'a> GitRepoIter<'a> {
 
     fn get_next(&mut self) -> CallState {
         // pop
-        // 
+        //
         // Use pop here to manage the lifetime of the iterator. If we used last/peek, we would
         // borrow a shared reference, which precludes us from borrowing as mutable when we want to
         // use the iterator. But that means we have to return it to the vec.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod database;
 pub mod git_repo_iter;
 pub mod log;
 pub mod logger;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use dura::snapshots;
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
-use dura::database::RuntimeDatabase;
+use dura::database::RuntimeLock;
 
 #[tokio::main]
 async fn main() {
@@ -182,7 +182,7 @@ fn unwatch_dir(path: &std::path::Path) {
 /// function does not actually kill a poller but instead indicates
 /// that any living poller should exit during their next check.
 fn kill() {
-    let mut runtime_db = RuntimeDatabase::load();
-    runtime_db.pid = None;
-    runtime_db.save();
+    let mut runtime_lock = RuntimeLock::load();
+    runtime_lock.pid = None;
+    runtime_lock.save();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use dura::snapshots;
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
+use dura::database::RuntimeDatabase;
 
 #[tokio::main]
 async fn main() {
@@ -181,7 +182,7 @@ fn unwatch_dir(path: &std::path::Path) {
 /// function does not actually kill a poller but instead indicates
 /// that any living poller should exit during their next check.
 fn kill() {
-    let mut config = Config::load();
-    config.pid = None;
-    config.save();
+    let mut runtime_db = RuntimeDatabase::load();
+    runtime_db.pid = None;
+    runtime_db.save();
 }

--- a/tests/startup_test.rs
+++ b/tests/startup_test.rs
@@ -2,84 +2,84 @@ mod util;
 
 use dura::config::Config;
 use std::fs;
-use dura::database::RuntimeDatabase;
+use dura::database::RuntimeLock;
 
 #[test]
 fn start_serve() {
     let mut dura = util::dura::Dura::new();
     assert_eq!(None, dura.pid(true));
-    assert_eq!(None, dura.get_runtime_db());
-    assert_eq!(None, dura.get_runtime_db());
+    assert_eq!(None, dura.get_runtime_lock());
+    assert_eq!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
     dura.wait();
 
     assert_ne!(None, dura.pid(true));
-    let runtime_db = dura.get_runtime_db();
-    assert_ne!(None, runtime_db);
-    assert_eq!(dura.pid(true), runtime_db.unwrap().pid);
+    let runtime_lock = dura.get_runtime_lock();
+    assert_ne!(None, runtime_lock);
+    assert_eq!(dura.pid(true), runtime_lock.unwrap().pid);
 }
 
 #[test]
 fn start_serve_with_null_pid_in_config() {
     let mut dura = util::dura::Dura::new();
-    let mut runtime_db = RuntimeDatabase::empty();
-    runtime_db.pid = None;
-    dura.save_runtime_db(&runtime_db);
+    let mut runtime_lock = RuntimeLock::empty();
+    runtime_lock.pid = None;
+    dura.save_runtime_lock(&runtime_lock);
 
     assert_eq!(None, dura.pid(true));
-    assert_ne!(None, dura.get_runtime_db());
+    assert_ne!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
     dura.wait();
 
     assert_ne!(None, dura.pid(true));
-    let runtime_db = dura.get_runtime_db();
-    assert_ne!(None, runtime_db);
-    assert_eq!(dura.pid(true), runtime_db.unwrap().pid);
+    let runtime_lock = dura.get_runtime_lock();
+    assert_ne!(None, runtime_lock);
+    assert_eq!(dura.pid(true), runtime_lock.unwrap().pid);
 }
 
 #[test]
 fn start_serve_with_other_pid_in_config() {
     let mut dura = util::dura::Dura::new();
-    let mut runtime_db = RuntimeDatabase::empty();
-    runtime_db.pid = Some(12345);
-    dura.save_runtime_db(&runtime_db);
+    let mut runtime_lock = RuntimeLock::empty();
+    runtime_lock.pid = Some(12345);
+    dura.save_runtime_lock(&runtime_lock);
 
-    println!("db:: {:?}", dura.get_runtime_db());
+    println!("db:: {:?}", dura.get_runtime_lock());
 
     assert_eq!(None, dura.pid(true));
-    assert_ne!(None, dura.get_runtime_db());
+    assert_ne!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
     dura.wait();
 
     assert_ne!(None, dura.pid(true));
-    let runtime_db = dura.get_runtime_db();
-    assert_ne!(None, runtime_db);
-    assert_eq!(dura.pid(true), runtime_db.unwrap().pid);
+    let runtime_lock = dura.get_runtime_lock();
+    assert_ne!(None, runtime_lock);
+    assert_eq!(dura.pid(true), runtime_lock.unwrap().pid);
 }
 
 #[test]
 fn start_serve_with_invalid_json() {
     let mut dura = util::dura::Dura::new();
-    let runtime_db_path = dura.runtime_db_path();
-    Config::create_dir(runtime_db_path.as_path());
+    let runtime_lock_path = dura.runtime_lock_path();
+    Config::create_dir(runtime_lock_path.as_path());
     fs::write(
-        runtime_db_path,
+        runtime_lock_path,
         "{\"pid\":34725",
     )
     .unwrap();
 
     assert_eq!(None, dura.pid(true));
-    assert_eq!(None, dura.get_runtime_db());
+    assert_eq!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
     dura.wait();
 
     assert_ne!(None, dura.pid(true));
-    let runtime_db = dura.get_runtime_db();
-    assert_ne!(None, runtime_db);
-    assert_eq!(dura.pid(true), runtime_db.unwrap().pid);
+    let runtime_lock = dura.get_runtime_lock();
+    assert_ne!(None, runtime_lock);
+    assert_eq!(dura.pid(true), runtime_lock.unwrap().pid);
 }
 

--- a/tests/startup_test.rs
+++ b/tests/startup_test.rs
@@ -9,7 +9,6 @@ fn start_serve() {
     let mut dura = util::dura::Dura::new();
     assert_eq!(None, dura.pid(true));
     assert_eq!(None, dura.get_runtime_lock());
-    assert_eq!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
     dura.wait();

--- a/tests/startup_test.rs
+++ b/tests/startup_test.rs
@@ -2,80 +2,84 @@ mod util;
 
 use dura::config::Config;
 use std::fs;
+use dura::database::RuntimeDatabase;
 
 #[test]
 fn start_serve() {
     let mut dura = util::dura::Dura::new();
     assert_eq!(None, dura.pid(true));
-    assert_eq!(None, dura.get_config());
+    assert_eq!(None, dura.get_runtime_db());
+    assert_eq!(None, dura.get_runtime_db());
 
     dura.start_async(&["serve"], true);
     dura.wait();
 
     assert_ne!(None, dura.pid(true));
-    let cfg = dura.get_config();
-    assert_ne!(None, cfg);
-    assert_eq!(dura.pid(true), cfg.unwrap().pid);
+    let runtime_db = dura.get_runtime_db();
+    assert_ne!(None, runtime_db);
+    assert_eq!(dura.pid(true), runtime_db.unwrap().pid);
 }
 
 #[test]
 fn start_serve_with_null_pid_in_config() {
     let mut dura = util::dura::Dura::new();
-    let mut cfg = Config::empty();
-    cfg.pid = None;
-    dura.save_config(&cfg);
+    let mut runtime_db = RuntimeDatabase::empty();
+    runtime_db.pid = None;
+    dura.save_runtime_db(&runtime_db);
 
     assert_eq!(None, dura.pid(true));
-    assert_ne!(None, dura.get_config());
+    assert_ne!(None, dura.get_runtime_db());
 
     dura.start_async(&["serve"], true);
     dura.wait();
 
     assert_ne!(None, dura.pid(true));
-    let cfg = dura.get_config();
-    assert_ne!(None, cfg);
-    assert_eq!(dura.pid(true), cfg.unwrap().pid);
+    let runtime_db = dura.get_runtime_db();
+    assert_ne!(None, runtime_db);
+    assert_eq!(dura.pid(true), runtime_db.unwrap().pid);
 }
 
 #[test]
 fn start_serve_with_other_pid_in_config() {
     let mut dura = util::dura::Dura::new();
-    let mut cfg = Config::empty();
-    cfg.pid = Some(12345);
-    dura.save_config(&cfg);
+    let mut runtime_db = RuntimeDatabase::empty();
+    runtime_db.pid = Some(12345);
+    dura.save_runtime_db(&runtime_db);
+
+    println!("db:: {:?}", dura.get_runtime_db());
 
     assert_eq!(None, dura.pid(true));
-    assert_ne!(None, dura.get_config());
+    assert_ne!(None, dura.get_runtime_db());
 
     dura.start_async(&["serve"], true);
     dura.wait();
 
     assert_ne!(None, dura.pid(true));
-    let cfg = dura.get_config();
-    assert_ne!(None, cfg);
-    assert_eq!(dura.pid(true), cfg.unwrap().pid);
+    let runtime_db = dura.get_runtime_db();
+    assert_ne!(None, runtime_db);
+    assert_eq!(dura.pid(true), runtime_db.unwrap().pid);
 }
 
 #[test]
 fn start_serve_with_invalid_json() {
     let mut dura = util::dura::Dura::new();
-    let cfg_path = dura.config_path();
-    Config::create_dir(cfg_path.as_path());
+    let runtime_db_path = dura.runtime_db_path();
+    Config::create_dir(runtime_db_path.as_path());
     fs::write(
-        cfg_path,
-        "{\"pid\":34725,\"repos\":{}}Users/timkellogg/code/dura\":{}}}",
+        runtime_db_path,
+        "{\"pid\":34725",
     )
     .unwrap();
 
     assert_eq!(None, dura.pid(true));
-    assert_eq!(None, dura.get_config());
+    assert_eq!(None, dura.get_runtime_db());
 
     dura.start_async(&["serve"], true);
     dura.wait();
 
     assert_ne!(None, dura.pid(true));
-    let cfg = dura.get_config();
-    assert_ne!(None, cfg);
-    assert_eq!(dura.pid(true), cfg.unwrap().pid);
+    let runtime_db = dura.get_runtime_db();
+    assert_ne!(None, runtime_db);
+    assert_eq!(dura.pid(true), runtime_db.unwrap().pid);
 }
 

--- a/tests/util/dura.rs
+++ b/tests/util/dura.rs
@@ -6,7 +6,7 @@ use std::{
 use std::collections::HashSet;
 
 use dura::config::Config;
-use dura::database::RuntimeDatabase;
+use dura::database::RuntimeLock;
 
 /// Utility to start dura asynchronously (e.g. dura serve) and kill the process when this goes out
 /// of scope. This helps us do end-to-end tests where we invoke the executable, possibly multiple
@@ -120,18 +120,18 @@ impl Dura {
         cfg.save_to_path(self.config_path().as_path());
     }
 
-    pub fn runtime_db_path(&self) -> path::PathBuf {
+    pub fn runtime_lock_path(&self) -> path::PathBuf {
         self.cache_dir.path().join("runtime.db")
     }
 
-    pub fn get_runtime_db(&self) -> Option<RuntimeDatabase> {
+    pub fn get_runtime_lock(&self) -> Option<RuntimeLock> {
         println!("$ cat ~/.cache/dura/runtime.db");
-        let cfg = RuntimeDatabase::load_file(self.runtime_db_path().as_path()).ok();
+        let cfg = RuntimeLock::load_file(self.runtime_lock_path().as_path()).ok();
         println!("{:?}", cfg);
         cfg
     }
 
-    pub fn save_runtime_db(&self, cfg: &RuntimeDatabase) {
+    pub fn save_runtime_lock(&self, cfg: &RuntimeLock) {
         cfg.save_to_path(self.config_path().as_path());
     }
 

--- a/tests/util/dura.rs
+++ b/tests/util/dura.rs
@@ -113,10 +113,10 @@ impl Dura {
         cfg.save_to_path(self.config_path().as_path());
     }
 
-    pub fn git_repos(&self) -> Vec<path::PathBuf> {
+    pub fn git_repos(&self) -> HashSet<path::PathBuf> {
         match self.get_config() {
             Some(cfg) => cfg.git_repos().collect(),
-            None => vec![],
+            None => HashSet::new(),
         }
     }
 

--- a/tests/util/dura.rs
+++ b/tests/util/dura.rs
@@ -3,8 +3,10 @@ use std::{
     process::{Child, Command},
     thread, time,
 };
+use std::collections::HashSet;
 
 use dura::config::Config;
+use dura::database::RuntimeDatabase;
 
 /// Utility to start dura asynchronously (e.g. dura serve) and kill the process when this goes out
 /// of scope. This helps us do end-to-end tests where we invoke the executable, possibly multiple
@@ -12,7 +14,8 @@ use dura::config::Config;
 pub struct Dura {
     primary: Option<Child>,
     secondary: Option<Child>,
-    home_dir: tempfile::TempDir,
+    config_dir: tempfile::TempDir,
+    cache_dir: tempfile::TempDir,
 }
 
 impl Dura {
@@ -20,7 +23,8 @@ impl Dura {
         Self {
             primary: None,
             secondary: None,
-            home_dir: tempfile::tempdir().unwrap(),
+            config_dir: tempfile::tempdir().unwrap(),
+            cache_dir: tempfile::tempdir().unwrap(),
         }
     }
 
@@ -29,7 +33,8 @@ impl Dura {
         let exe = env!("CARGO_BIN_EXE_dura").to_string();
         let child = Command::new(exe)
             .args(args)
-            .env("DURA_HOME", self.home_dir.path())
+            .env("DURA_CONFIG_HOME", self.config_dir.path())
+            .env("DURA_CACHE_HOME", self.cache_dir.path())
             .spawn()
             .unwrap();
 
@@ -45,7 +50,8 @@ impl Dura {
         let exe = env!("CARGO_BIN_EXE_dura").to_string();
         let child_proc = Command::new(exe)
             .args(args)
-            .env("DURA_HOME", self.home_dir.path())
+            .env("DURA_CONFIG_HOME", self.config_dir.path())
+            .env("DURA_CACHE_HOME", self.cache_dir.path())
             .output();
 
         if let Ok(output) = child_proc {
@@ -69,7 +75,8 @@ impl Dura {
         let exe = env!("CARGO_BIN_EXE_dura").to_string();
         let child_proc = Command::new(exe)
             .args(args)
-            .env("DURA_HOME", self.home_dir.path())
+            .env("DURA_CONFIG_HOME", self.config_dir.path())
+            .env("DURA_CACHE_HOME", self.cache_dir.path())
             .current_dir(dir)
             .output();
 
@@ -99,17 +106,32 @@ impl Dura {
     }
 
     pub fn config_path(&self) -> path::PathBuf {
-        self.home_dir.path().join("config.json")
+        self.config_dir.path().join("config.toml")
     }
 
     pub fn get_config(&self) -> Option<Config> {
-        println!("$ cat ~/.config/dura/config.json");
+        println!("$ cat ~/.config/dura/config.toml");
         let cfg = Config::load_file(self.config_path().as_path()).ok();
         println!("{:?}", cfg);
         cfg
     }
 
     pub fn save_config(&self, cfg: &Config) {
+        cfg.save_to_path(self.config_path().as_path());
+    }
+
+    pub fn runtime_db_path(&self) -> path::PathBuf {
+        self.cache_dir.path().join("runtime.db")
+    }
+
+    pub fn get_runtime_db(&self) -> Option<RuntimeDatabase> {
+        println!("$ cat ~/.cache/dura/runtime.db");
+        let cfg = RuntimeDatabase::load_file(self.runtime_db_path().as_path()).ok();
+        println!("{:?}", cfg);
+        cfg
+    }
+
+    pub fn save_runtime_db(&self, cfg: &RuntimeDatabase) {
         cfg.save_to_path(self.config_path().as_path());
     }
 

--- a/tests/watch_test.rs
+++ b/tests/watch_test.rs
@@ -1,5 +1,6 @@
 mod util;
 
+use std::collections::HashSet;
 use crate::util::dura::Dura;
 use crate::util::git_repo::GitRepo;
 
@@ -8,10 +9,14 @@ fn watch_repo() {
     let tmp = tempfile::tempdir().unwrap();
     let repo = GitRepo::new(tmp.path().to_path_buf());
     repo.init();
-    
+
     let dura = Dura::new();
     dura.run_in_dir(&["watch"], tmp.path());
-    assert_eq!(dura.git_repos(), vec![tmp.path().canonicalize().unwrap()]);
+
+    let mut tmp_set = HashSet::new();
+    tmp_set.insert(tmp.path().canonicalize().unwrap());
+
+    assert_eq!(dura.git_repos(), tmp_set);
 }
 
 #[test]
@@ -21,13 +26,15 @@ fn watch_1_dir_with_2_repos() {
     repo1.init();
     let repo2 = GitRepo::new(tmp.path().join("repo2"));
     repo2.init();
-    
+
     let dura = Dura::new();
     dura.run_in_dir(&["watch"], tmp.path());
-    assert_eq!(dura.git_repos(), vec![
-        repo1.dir.canonicalize().unwrap(),
-        repo2.dir.canonicalize().unwrap(),
-    ]);
+
+    let mut tmp_set = HashSet::new();
+    tmp_set.insert(repo1.dir.canonicalize().unwrap());
+    tmp_set.insert(repo2.dir.canonicalize().unwrap());
+
+    assert_eq!(dura.git_repos(), tmp_set);
 }
 
 #[test]
@@ -35,9 +42,13 @@ fn watch_dir_with_repo_nested_3_folders_deep() {
     let tmp = tempfile::tempdir().unwrap();
     let repo = GitRepo::new(tmp.path().join("a/b/c"));
     repo.init();
-    
+
     let dura = Dura::new();
     dura.run_in_dir(&["watch"], tmp.path());
-    assert_eq!(dura.git_repos(), vec![repo.dir.canonicalize().unwrap()]);
+
+    let mut tmp_set = HashSet::new();
+    tmp_set.insert(repo.dir.canonicalize().unwrap());
+
+    assert_eq!(dura.git_repos(), tmp_set);
 }
 


### PR DESCRIPTION
Associated: #28 

The repo config and runtime database are now separate. The config is stored in `.config/dura/config.toml` and the runtime database (PID) is stored in .cache/dura/runtime.db (in JSON format).

The `home` package has been replaced with `dirs` [(crate)](https://crates.io/crates/dirs) for better support for user directories. This means getting the config/cache dir should always work across OS.

The `DURA_HOME` env var has been replaced with `DURA_CONFIG_HOME` and `DURA_CACHE_HOME` to accommodate the change.

A couple of flaky runtime tests have also been fixed to use `HashSet` instead of `Vec`, as collecting the repo `HashMap` keys didn't guarantee the same order and could sometimes incorrectly fail.

Example runtime DB:

```json
{"pid":34143}
```

Example config file:
```toml
[repos."/home/jake/aur"]
include = []
exclude = []
max_depth = 255

[repos."/home/jake/Programming"]
include = ["third-party/dura"]
exclude = ["third-party", "something-else"]
max_depth = 3
```

## A couple of things before this is merged:

- This will cause a reset of all Dura installs since the old config file (and so any previously watched dirs) is ignored
- Two of the tests are failing at the moment, although I *think* they're false cases where they just need updating. Want to run that past you first before changing them & breaking something.
 