### PR TITLE
feat: Use dura config and git config for commit signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "git2",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "toml",
@@ -564,6 +565,28 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"
+serial_test = "0.5.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,17 +36,23 @@ impl Default for WatchConfig {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Config {
-    pub repos: BTreeMap<String, Rc<WatchConfig>>,
+    // When commit_exclude_git_config is true,
+    // never use any git configuration to sign dura's commits.
+    // Defaults to false
+    #[serde(default)]
+    pub commit_exclude_git_config: bool,
     pub commit_author: Option<String>,
     pub commit_email: Option<String>,
+    pub repos: BTreeMap<String, Rc<WatchConfig>>,
 }
 
 impl Config {
     pub fn empty() -> Self {
         Self {
-            repos: BTreeMap::new(),
+            commit_exclude_git_config: false,
             commit_author: None,
             commit_email: None,
+            repos: BTreeMap::new(),
         }
     }
 
@@ -99,7 +105,10 @@ impl Config {
     pub fn save_to_path(&self, path: &Path) {
         Self::create_dir(path);
 
-        fs::write(path, toml::to_string(self).unwrap()).unwrap();
+        match fs::write(path, toml::to_string(self).unwrap()) {
+            Ok(_) => (),
+            Err(e) => println!("Unable to initialize dura config file: {}", e),
+        }
     }
 
     pub fn set_watch(&mut self, path: String, cfg: WatchConfig) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,12 +37,16 @@ impl Default for WatchConfig {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Config {
     pub repos: BTreeMap<String, Rc<WatchConfig>>,
+    pub commit_author: Option<String>,
+    pub commit_email: Option<String>,
 }
 
 impl Config {
     pub fn empty() -> Self {
         Self {
             repos: BTreeMap::new(),
+            commit_author: None,
+            commit_email: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,13 @@ use std::path::Path;
 
 use clap::{arg, App, AppSettings, Arg, Values};
 use dura::config::{Config, WatchConfig};
+use dura::database::RuntimeLock;
 use dura::logger::NestedJsonLayer;
 use dura::poller;
 use dura::snapshots;
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
-use dura::database::RuntimeLock;
 
 #[tokio::main]
 async fn main() {

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -10,7 +10,6 @@ use crate::database::RuntimeLock;
 use crate::log::Operation;
 use crate::snapshots;
 
-
 /// If the directory is a repo, attempts to create a snapshot.
 /// Otherwise, recurses into each child directory.
 #[tracing::instrument]

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -86,9 +86,11 @@ fn get_git_author(repo: &Repository) -> String {
         return value;
     }
 
-    if let Ok(git_cfg) = repo.config() {
-        if let Ok(value) = git_cfg.get_string("user.name") {
-            return value;
+    if !dura_cfg.commit_exclude_git_config {
+        if let Ok(git_cfg) = repo.config() {
+            if let Ok(value) = git_cfg.get_string("user.name") {
+                return value;
+            }
         }
     }
 
@@ -101,9 +103,11 @@ fn get_git_email(repo: &Repository) -> String {
         return value;
     }
 
-    if let Ok(git_cfg) = repo.config() {
-        if let Ok(value) = git_cfg.get_string("user.email") {
-            return value;
+    if !dura_cfg.commit_exclude_git_config {
+        if let Ok(git_cfg) = repo.config() {
+            if let Ok(value) = git_cfg.get_string("user.email") {
+                return value;
+            }
         }
     }
 

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -1,7 +1,7 @@
+use git2::{BranchType, Commit, DiffOptions, Error, IndexAddOption, Repository, Signature};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::path::Path;
-use git2::{Repository, Error, IndexAddOption, Commit, BranchType, DiffOptions, Signature};
-use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
 
@@ -14,7 +14,11 @@ pub struct CaptureStatus {
 
 impl fmt::Display for CaptureStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "dura: {}, commit_hash: {}, base: {}", self.dura_branch, self.commit_hash, self.base_hash)
+        write!(
+            f,
+            "dura: {}, commit_hash: {}, base: {}",
+            self.dura_branch, self.commit_hash, self.base_hash
+        )
     }
 }
 
@@ -44,12 +48,12 @@ pub fn capture(path: &Path) -> Result<Option<CaptureStatus>, Error> {
     index.add_all(["*"].iter(), IndexAddOption::DEFAULT, None)?;
 
     let dirty_diff = repo.diff_tree_to_index(
-        Some(&branch_commit.as_ref().unwrap_or(&head).tree()?), 
-        Some(&index), 
-        Some(DiffOptions::new().include_untracked(true))
+        Some(&branch_commit.as_ref().unwrap_or(&head).tree()?),
+        Some(&index),
+        Some(DiffOptions::new().include_untracked(true)),
     )?;
     if dirty_diff.deltas().len() == 0 {
-        return Ok(None)
+        return Ok(None);
     }
 
     let tree_oid = index.write_tree()?;
@@ -62,7 +66,7 @@ pub fn capture(path: &Path) -> Result<Option<CaptureStatus>, Error> {
         &committer,
         message,
         &tree,
-        &[ branch_commit.as_ref().unwrap_or(&head) ],
+        &[branch_commit.as_ref().unwrap_or(&head)],
     )?;
 
     Ok(Some(CaptureStatus {

--- a/tests/snapshots_test.rs
+++ b/tests/snapshots_test.rs
@@ -1,4 +1,4 @@
-use dura::{ snapshots, config::Config };
+use dura::{config::Config, snapshots};
 
 use std::env;
 
@@ -82,7 +82,7 @@ fn test_commit_signature_using_dura_config() {
     repo.set_config("user.email", "git@someemail.com");
 
     env::set_var("DURA_CONFIG_HOME", tmp.path().to_path_buf());
-    let mut dura_config = Config::empty(); 
+    let mut dura_config = Config::empty();
     dura_config.commit_author = Some("dura-config".to_string());
     dura_config.commit_email = Some("dura-config@email.com".to_string());
     dura_config.save();
@@ -94,7 +94,7 @@ fn test_commit_signature_using_dura_config() {
     let status = snapshots::capture(repo.dir.as_path()).unwrap().unwrap();
 
     let commit_author = repo.git(&["show", "-s", "--format=format:%an", &status.commit_hash]);
-    assert_eq!(commit_author, dura_config.commit_author); 
+    assert_eq!(commit_author, dura_config.commit_author);
 
     let commit_email = repo.git(&["show", "-s", "--format=format:%ae", &status.commit_hash]);
     assert_eq!(commit_email, dura_config.commit_email);
@@ -110,7 +110,7 @@ fn test_commit_signature_using_git_config() {
     repo.set_config("user.email", "git@someemail.com");
 
     env::set_var("DURA_CONFIG_HOME", tmp.path().to_path_buf());
-    let mut dura_config = Config::empty(); 
+    let mut dura_config = Config::empty();
     dura_config.save();
 
     repo.write_file("foo.txt");
@@ -119,11 +119,15 @@ fn test_commit_signature_using_git_config() {
     repo.change_file("foo.txt");
     let status = snapshots::capture(repo.dir.as_path()).unwrap().unwrap();
 
-    let commit_author = repo.git(&["show", "-s", "--format=format:%an", &status.commit_hash]).unwrap();
-    assert_eq!(commit_author, "git-author"); 
+    let commit_author = repo
+        .git(&["show", "-s", "--format=format:%an", &status.commit_hash])
+        .unwrap();
+    assert_eq!(commit_author, "git-author");
 
-    let commit_email = repo.git(&["show", "-s", "--format=format:%ae", &status.commit_hash]).unwrap();
-    assert_eq!(commit_email, "git@someemail.com"); 
+    let commit_email = repo
+        .git(&["show", "-s", "--format=format:%ae", &status.commit_hash])
+        .unwrap();
+    assert_eq!(commit_email, "git@someemail.com");
 }
 
 #[test]
@@ -136,7 +140,7 @@ fn test_commit_signature_exclude_git_config() {
     repo.set_config("user.email", "git@someemail.com");
 
     env::set_var("DURA_CONFIG_HOME", tmp.path().to_path_buf());
-    let mut dura_config = Config::empty(); 
+    let mut dura_config = Config::empty();
     dura_config.commit_exclude_git_config = true;
     dura_config.save();
 
@@ -145,9 +149,13 @@ fn test_commit_signature_exclude_git_config() {
     repo.change_file("foo.txt");
     let status = snapshots::capture(repo.dir.as_path()).unwrap().unwrap();
 
-    let commit_author = repo.git(&["show", "-s", "--format=format:%an", &status.commit_hash]).unwrap();
-    assert_eq!(commit_author, "dura"); 
+    let commit_author = repo
+        .git(&["show", "-s", "--format=format:%an", &status.commit_hash])
+        .unwrap();
+    assert_eq!(commit_author, "dura");
 
-    let commit_email = repo.git(&["show", "-s", "--format=format:%ae", &status.commit_hash]).unwrap();
-    assert_eq!(commit_email, "dura@github.io"); 
+    let commit_email = repo
+        .git(&["show", "-s", "--format=format:%ae", &status.commit_hash])
+        .unwrap();
+    assert_eq!(commit_email, "dura@github.io");
 }

--- a/tests/startup_test.rs
+++ b/tests/startup_test.rs
@@ -1,8 +1,8 @@
 mod util;
 
 use dura::config::Config;
-use std::fs;
 use dura::database::RuntimeLock;
+use std::fs;
 
 #[test]
 fn start_serve() {
@@ -64,11 +64,7 @@ fn start_serve_with_invalid_json() {
     let mut dura = util::dura::Dura::new();
     let runtime_lock_path = dura.runtime_lock_path();
     Config::create_dir(runtime_lock_path.as_path());
-    fs::write(
-        runtime_lock_path,
-        "{\"pid\":34725",
-    )
-    .unwrap();
+    fs::write(runtime_lock_path, "{\"pid\":34725").unwrap();
 
     assert_eq!(None, dura.pid(true));
     assert_eq!(None, dura.get_runtime_lock());
@@ -81,4 +77,3 @@ fn start_serve_with_invalid_json() {
     assert_ne!(None, runtime_lock);
     assert_eq!(dura.pid(true), runtime_lock.unwrap().pid);
 }
-

--- a/tests/util/dura.rs
+++ b/tests/util/dura.rs
@@ -1,9 +1,9 @@
+use std::collections::HashSet;
 use std::{
     ops, path,
     process::{Child, Command},
     thread, time,
 };
-use std::collections::HashSet;
 
 use dura::config::Config;
 use dura::database::RuntimeLock;
@@ -95,7 +95,6 @@ impl Dura {
             }
         }
     }
-
 
     pub fn pid(&self, is_primary: bool) -> Option<u32> {
         if is_primary {

--- a/tests/util/git_repo.rs
+++ b/tests/util/git_repo.rs
@@ -79,4 +79,8 @@ impl GitRepo {
         let path_obj = self.dir.as_path().join(path);
         fs::write(path_obj, content).unwrap();
     }
+
+    pub fn set_config(&self, name: &str, value: &str) {
+        self.git(&["config", name, value]);
+    }
 }

--- a/tests/util/workspace.rs
+++ b/tests/util/workspace.rs
@@ -1,0 +1,17 @@
+mod util;
+
+/// Test utility to set up test dura environment
+pub struct Workspace {
+    pub dir: path::PathBuf,
+    pub config_dir
+}
+
+impl Workspace {
+    pub fn new(dir: path::PathBuf) -> Self {
+        Self { dir }
+    }
+
+    pub fn init_dura(dir: path::PathBuf) -> Self {
+
+    }
+}

--- a/tests/watch_test.rs
+++ b/tests/watch_test.rs
@@ -1,8 +1,8 @@
 mod util;
 
-use std::collections::HashSet;
 use crate::util::dura::Dura;
 use crate::util::git_repo::GitRepo;
+use std::collections::HashSet;
 
 #[test]
 fn watch_repo() {
@@ -51,4 +51,3 @@ fn watch_dir_with_repo_nested_3_folders_deep() {
 
     assert_eq!(dura.git_repos(), tmp_set);
 }
-


### PR DESCRIPTION
Closes #21 

Previously, dura uses the latest commit to determine commit author and email, this PR aims to change the way dura determines this.

### changelog:

This PR allow specifying commit author and email in config file by adding 2 field in config:

- `commit_author`: preferred author for dura commits
- `commit_email`: preferred email for dura commits

When signing commit, dura will prefer the following order of preference when choosing author/email:

1. Dura config
2. Git config
3. Defaults to `author: dura`, `email: dura@github.io`

---

Planning to add more knob to allow user to choose between preference 2 and 3