### PR TITLE
Add commit sha to build artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [workflow_dispatch, push, pull_request]
+on: [workflow_call, workflow_dispatch, push, pull_request]
 
 jobs:
     build-linux:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
             - name: Upload Binary
               uses: actions/upload-artifact@v2
               with:
-                  name: dura-linux-x86_64
+                  name: dura-linux-x86_64_${{ github.sha }}
                   path: ${{ github.workspace }}/target/release/dura
 
     build-macos:
@@ -68,7 +68,7 @@ jobs:
             - name: Upload Binary
               uses: actions/upload-artifact@v2
               with:
-                  name: dura-macos-x86_64
+                  name: dura-macos-x86_64_${{ github.sha }}
                   path: ${{ github.workspace }}/target/release/dura
 
     build-windows:
@@ -102,5 +102,5 @@ jobs:
             - name: Upload Binary
               uses: actions/upload-artifact@v2
               with:
-                  name: dura-windows-x86_64
+                  name: dura-windows-x86_64_${{ github.sha }}
                   path: ${{ github.workspace }}\target\release\dura.exe


### PR DESCRIPTION
Hi,
This adds the commit sha256 sum to the end of the artifact names to differentiate between versions.

BTW, do you have any plans for a release schedule?
I can create a workflow for automatic releases.
I also added a pre-requisite for that in this commit: (https://github.com/tkellogg/dura/commit/1a09368649347e7ebbcfb40d6ed96a3f1f158fff)

Thanks