### PR TITLE
Fix tests: write runtime db

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,12 @@ jobs:
                   command: build
                   args: --release --all-features
 
+            - name: Cargo Test
+              uses: actions-rs/cargo@v1
+              with:
+                  command: test
+                  args: --profile release
+
             - name: Basic Testing
               continue-on-error: true
               run: |
@@ -58,6 +64,12 @@ jobs:
                   command: build
                   args: --release --all-features
 
+            - name: Cargo Test
+              uses: actions-rs/cargo@v1
+              with:
+                  command: test
+                  args: --profile release
+
             - name: Basic Testing
               continue-on-error: true
               run: |
@@ -91,6 +103,12 @@ jobs:
               with:
                   command: build
                   args: --release --all-features
+
+            - name: Cargo Test
+              uses: actions-rs/cargo@v1
+              with:
+                  command: test
+                  args: --profile release
 
             - name: Basic Testing
               continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "dura"
-version = "0.1.0"
+version = "0.2.0-snapshot"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dura"
-version = "0.1.0"
+version = "0.2.0-snapshot"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/snapshots_test.rs
+++ b/tests/snapshots_test.rs
@@ -30,7 +30,6 @@ fn no_changes() {
     repo.init();
     repo.write_file("foo.txt");
     repo.commit_all();
-    repo.git(&["log"]);
 
     let status = snapshots::capture(repo.dir.as_path()).unwrap();
 

--- a/tests/snapshots_test.rs
+++ b/tests/snapshots_test.rs
@@ -30,6 +30,7 @@ fn no_changes() {
     repo.init();
     repo.write_file("foo.txt");
     repo.commit_all();
+    repo.git(&["log"]);
 
     let status = snapshots::capture(repo.dir.as_path()).unwrap();
 

--- a/tests/snapshots_test.rs
+++ b/tests/snapshots_test.rs
@@ -61,7 +61,7 @@ fn during_merge_conflicts() {
     // MERGE FAIL
     let merge_result = repo.git(&["merge", "branch1"]);
     assert_eq!(merge_result, None);
-    repo.git(&["status"]); // debug info
+    repo.git(&["status"]).unwrap(); // debug info
 
     // change a file anyway
     repo.change_file("foo.txt");

--- a/tests/util/dura.rs
+++ b/tests/util/dura.rs
@@ -125,13 +125,13 @@ impl Dura {
 
     pub fn get_runtime_lock(&self) -> Option<RuntimeLock> {
         println!("$ cat ~/.cache/dura/runtime.db");
-        let cfg = RuntimeLock::load_file(self.runtime_lock_path().as_path()).ok();
-        println!("{:?}", cfg);
-        cfg
+        let cfg = RuntimeLock::load_file(self.runtime_lock_path().as_path());
+        println!("{:?}", &cfg);
+        cfg.ok()
     }
 
     pub fn save_runtime_lock(&self, cfg: &RuntimeLock) {
-        cfg.save_to_path(self.config_path().as_path());
+        cfg.save_to_path(self.runtime_lock_path().as_path());
     }
 
     pub fn git_repos(&self) -> HashSet<path::PathBuf> {

--- a/tests/util/git_repo.rs
+++ b/tests/util/git_repo.rs
@@ -55,6 +55,7 @@ impl GitRepo {
     pub fn init(&self) {
         fs::create_dir_all(self.dir.as_path()).unwrap();
         let _ = self.git(&["init"]);
+        let _ = self.git(&["--version"]);
         let _ = self.git(&["checkout", "-b", "master"]);
     }
 

--- a/tests/util/git_repo.rs
+++ b/tests/util/git_repo.rs
@@ -55,18 +55,18 @@ impl GitRepo {
 
     pub fn init(&self) {
         fs::create_dir_all(self.dir.as_path()).unwrap();
-        let _ = self.git(&["init"]);
-        let _ = self.git(&["--version"]);
-        let _ = self.git(&["checkout", "-b", "master"]);
+        let _ = self.git(&["init"]).unwrap();
+        let _ = self.git(&["--version"]).unwrap();
+        let _ = self.git(&["checkout", "-b", "master"]).unwrap();
         // Linux & Windows will fail on `git commit` if these aren't set
-        let _ = self.git(&["config", "user.name", "duratest"]);
-        let _ = self.git(&["config", "user.email", "duratest@dura.io"]);
+        let _ = self.git(&["config", "user.name", "duratest"]).unwrap();
+        let _ = self.git(&["config", "user.email", "duratest@dura.io"]).unwrap();
     }
 
     pub fn commit_all(&self) {
-        self.git(&["add", "."]);
-        self.git(&["status"]);
-        self.git(&["commit", "-m", "test"]);
+        self.git(&["add", "."]).unwrap();
+        self.git(&["status"]).unwrap();
+        self.git(&["commit", "-m", "test"]).unwrap();
     }
 
     pub fn write_file(&self, path: &str) {
@@ -86,6 +86,6 @@ impl GitRepo {
     }
 
     pub fn set_config(&self, name: &str, value: &str) {
-        self.git(&["config", name, value]);
+        self.git(&["config", name, value]).unwrap();
     }
 }

--- a/tests/util/git_repo.rs
+++ b/tests/util/git_repo.rs
@@ -34,10 +34,6 @@ impl GitRepo {
             .output();
 
         if let Ok(output) = child_proc {
-            if !output.status.success() {
-                // This cleans up test development by causing us to fail earlier
-                return None;
-            }
             let text = String::from_utf8(output.stdout).unwrap();
             if !text.is_empty() {
                 println!("{}", text);
@@ -46,7 +42,12 @@ impl GitRepo {
             if !err.is_empty() {
                 println!("{}", err);
             }
-            Some(text)
+            if !output.status.success() {
+                // This cleans up test development by causing us to fail earlier
+                None
+            } else {
+                Some(text)
+            }
         } else {
             None
         }

--- a/tests/util/git_repo.rs
+++ b/tests/util/git_repo.rs
@@ -58,6 +58,9 @@ impl GitRepo {
         let _ = self.git(&["init"]);
         let _ = self.git(&["--version"]);
         let _ = self.git(&["checkout", "-b", "master"]);
+        // Linux & Windows will fail on `git commit` if these aren't set
+        let _ = self.git(&["config", "user.name", "duratest"]);
+        let _ = self.git(&["config", "user.email", "duratest@dura.io"]);
     }
 
     pub fn commit_all(&self) {


### PR DESCRIPTION
Tests broke in #66 but we didn't catch it because our CI/CD pipeline
doesn't run cargo test. This also enables tests on all platforms.

Ping @JakeStanger 

closes #72