### PR TITLE
Fix test stability & speed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,6 @@ async fn main() {
                 }
             }
 
-            tracing::info!(pid = std::process::id());
             poller::start().await;
         }
         Some(("watch", arg_matches)) => {

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -64,6 +64,7 @@ pub async fn start() {
     let mut runtime_lock = RuntimeLock::load();
     runtime_lock.pid = Some(process::id());
     runtime_lock.save();
+    info!(pid = std::process::id());
 
     loop {
         time::sleep(time::Duration::from_secs(5)).await;

--- a/tests/startup_test.rs
+++ b/tests/startup_test.rs
@@ -5,7 +5,7 @@ use dura::database::RuntimeLock;
 use std::fs;
 
 /// How many seconds to wait, at most, for dura to start?
-const start_timeout = 8;
+const START_TIMEOUT: u64 = 8;
 
 #[test]
 fn start_serve() {
@@ -14,7 +14,7 @@ fn start_serve() {
     assert_eq!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(start_timeout).unwrap());
+    dura.primary.as_ref().map(|d| d.read_line(START_TIMEOUT).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -33,7 +33,7 @@ fn start_serve_with_null_pid_in_config() {
     assert_ne!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(start_timeout).unwrap());
+    dura.primary.as_ref().map(|d| d.read_line(START_TIMEOUT).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -54,7 +54,7 @@ fn start_serve_with_other_pid_in_config() {
     assert_ne!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(start_timeout).unwrap());
+    dura.primary.as_ref().map(|d| d.read_line(START_TIMEOUT).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -73,7 +73,7 @@ fn start_serve_with_invalid_json() {
     assert_eq!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(start_timeout).unwrap());
+    dura.primary.as_ref().map(|d| d.read_line(START_TIMEOUT).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();

--- a/tests/startup_test.rs
+++ b/tests/startup_test.rs
@@ -4,6 +4,9 @@ use dura::config::Config;
 use dura::database::RuntimeLock;
 use std::fs;
 
+/// How many seconds to wait, at most, for dura to start?
+const start_timeout = 8;
+
 #[test]
 fn start_serve() {
     let mut dura = util::dura::Dura::new();
@@ -11,7 +14,7 @@ fn start_serve() {
     assert_eq!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(8).unwrap());
+    dura.primary.as_ref().map(|d| d.read_line(start_timeout).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -30,7 +33,7 @@ fn start_serve_with_null_pid_in_config() {
     assert_ne!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(8).unwrap());
+    dura.primary.as_ref().map(|d| d.read_line(start_timeout).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -51,7 +54,7 @@ fn start_serve_with_other_pid_in_config() {
     assert_ne!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(8).unwrap());
+    dura.primary.as_ref().map(|d| d.read_line(start_timeout).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -70,7 +73,7 @@ fn start_serve_with_invalid_json() {
     assert_eq!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(8).unwrap());
+    dura.primary.as_ref().map(|d| d.read_line(start_timeout).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();

--- a/tests/startup_test.rs
+++ b/tests/startup_test.rs
@@ -11,7 +11,7 @@ fn start_serve() {
     assert_eq!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.wait();
+    dura.primary.as_ref().map(|d| d.read_line(8).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -30,7 +30,7 @@ fn start_serve_with_null_pid_in_config() {
     assert_ne!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.wait();
+    dura.primary.as_ref().map(|d| d.read_line(8).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -51,7 +51,7 @@ fn start_serve_with_other_pid_in_config() {
     assert_ne!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.wait();
+    dura.primary.as_ref().map(|d| d.read_line(8).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -70,7 +70,7 @@ fn start_serve_with_invalid_json() {
     assert_eq!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.wait();
+    dura.primary.as_ref().map(|d| d.read_line(8).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();

--- a/tests/util/daemon.rs
+++ b/tests/util/daemon.rs
@@ -1,0 +1,75 @@
+use std::io::{BufReader, BufRead};
+use std::process::{Child, ChildStdout};
+use std::sync::mpsc::{Receiver, channel};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+/// Main-thread side of a process watcher. The process that's launched is exposed as messages
+/// (per-line) over a mpsc channel. This is intended to simplify, speed up, and generally make the
+/// tests more reliable when they dispatch asynchronously to `dura serve`. However, nothing abot
+/// this is intended to be specific to dura.
+pub struct Daemon {
+   mailbox: Receiver<Option<String>>, 
+   pub child: Child,
+   /// Signals to kill daemon thread if this goes <= 0, like a CountDownLatch
+   kill_sign: Arc<Mutex<i32>>,
+}
+
+impl Daemon {
+    pub fn new(mut child: Child) -> Self {
+        let kill_sign = Arc::new(Mutex::new(1));
+        Self {
+            mailbox: Self::attach(
+               child.stdout.take().expect("Configure Command to capture stdout"),
+               Arc::clone(&kill_sign),
+            ),
+            child,
+            kill_sign,
+        }
+    }
+
+    /// Spawn another thread to watch the child process. It attaches to stdout and sends each line
+    /// over the channel. It sends a None right before it quits, either due to an error or EOF.
+    fn attach(stdout: ChildStdout, kill_sign: Arc<Mutex<i32>>) -> Receiver<Option<String>> {
+        let (sender, receiver) = channel();
+        thread::spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            loop {
+                {
+                    // check to see if the daemon is killed
+                    if *kill_sign.lock().unwrap() <= 0 {
+                        break;
+                    }
+                }
+                let mut line = String::new();
+                match reader.read_line(&mut line) {
+                    Ok(0) => {
+                        sender.send(None).unwrap();
+                        break;
+                    }
+                    Ok(_) => {
+                        sender.send(Some(line)).unwrap();
+                    }
+                    Err(e) => {
+                        eprintln!("Error in daemon: {:?}", e);
+                        sender.send(None).unwrap();
+                        break;
+                    }
+                }
+            }
+        });
+        receiver
+    }
+
+    /// Read a line from the child process, waiting at most timeout_secs.
+    pub fn read_line(&self, timeout_secs: u64) -> Option<String> {
+        self.mailbox.recv_timeout(Duration::from_secs(timeout_secs)).unwrap()
+    }
+
+    pub fn kill(&mut self) {
+        let mut kill_sign = self.kill_sign.lock().unwrap();
+        *kill_sign -= 1;
+        self.child.kill().unwrap();
+    }
+}

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -3,3 +3,4 @@
 
 pub mod dura;
 pub mod git_repo;
+pub mod daemon;


### PR DESCRIPTION
I noticed that startup tests fail on very slow machines, like the build hosts. I also hate that there's a 6 second `thread::sleep`. This PR fixes both of those problems. Tests run in <1s.

To do this, I created `Daemon`, that sets up a mpsc (technically an spsc) channel that sends each line of stdout (from `dura serve`) as a message to the test. This lets tests do a `read_line` to wait until output is printed, or do it twice to wait for the first snapshot event. It's a great way to communicate between parent and child processes.