### PR TITLE
Fix clippy errors, add clippy to CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,6 @@ trim_trailing_whitespace = false
 
 [*.yml]
 indent_size = 2
+
+[*.yaml]
+indent_size = 2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,124 +1,71 @@
 name: Build
 
-on: [workflow_call, workflow_dispatch, push, pull_request]
+on: [ workflow_call, workflow_dispatch, push, pull_request ]
 
 jobs:
-    build-linux:
-        name: build-linux
-        runs-on: ubuntu-latest
+  build:
+    name: build-linux
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            binary-suffix: linux-x86_64
+          - os: macos-latest
+            binary-suffix: macos-x86_64
+          - os: windows-latest
+            binary-suffix: windows-x86_64
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
-        steps:
-            - name: Check out source files
-              uses: actions/checkout@v2
-              with:
-                  fetch-depth: 1
+    steps:
+      - name: Check out source files
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
-            - name: Update Toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
+      - name: Update Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
 
-            - name: Build
-              uses: actions-rs/cargo@v1
-              with:
-                  command: build
-                  args: --release --all-features
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features
 
-            - name: Cargo Test
-              uses: actions-rs/cargo@v1
-              with:
-                  command: test
-                  args: --profile release
+      - name: Cargo Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets --all-features -- -D warnings
 
-            - name: Basic Testing
-              continue-on-error: true
-              run: |
-                  ${{ github.workspace }}/target/release/dura serve &
-                  sleep 15s
-                  ${{ github.workspace }}/target/release/dura kill
+      - name: Cargo Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --profile release
 
-            - name: Upload Binary
-              uses: actions/upload-artifact@v2
-              with:
-                  name: dura-linux-x86_64_${{ github.sha }}
-                  path: ${{ github.workspace }}/target/release/dura
+      - name: Basic Testing
+        continue-on-error: true
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          ${{ github.workspace }}/target/release/dura serve &
+          sleep 15s
+          ${{ github.workspace }}/target/release/dura kill
 
-    build-macos:
-        name: build-macos
-        runs-on: macos-latest
+      - name: Basic Testing (Windows)
+        continue-on-error: true
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          Start-Process -NoNewWindow ${{ github.workspace }}\target\release\dura.exe serve
+          Start-Sleep -s 15
+          ${{ github.workspace }}\target\release\dura.exe kill
 
-        steps:
-            - name: Check out source files
-              uses: actions/checkout@v2
-              with:
-                  fetch-depth: 1
+      - name: Upload Binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: dura-${{ matrix.binary-suffix }}_${{ github.sha }}
+          path: ${{ github.workspace }}/target/release/dura
 
-            - name: Update Toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-
-            - name: Build
-              uses: actions-rs/cargo@v1
-              with:
-                  command: build
-                  args: --release --all-features
-
-            - name: Cargo Test
-              uses: actions-rs/cargo@v1
-              with:
-                  command: test
-                  args: --profile release
-
-            - name: Basic Testing
-              continue-on-error: true
-              run: |
-                  ${{ github.workspace }}/target/release/dura serve &
-                  sleep 15s
-                  ${{ github.workspace }}/target/release/dura kill
-
-            - name: Upload Binary
-              uses: actions/upload-artifact@v2
-              with:
-                  name: dura-macos-x86_64_${{ github.sha }}
-                  path: ${{ github.workspace }}/target/release/dura
-
-    build-windows:
-        name: build-windows
-        runs-on: windows-latest
-
-        steps:
-            - name: Check out source files
-              uses: actions/checkout@v2
-              with:
-                  fetch-depth: 1
-
-            - name: Update Toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-
-            - name: Build
-              uses: actions-rs/cargo@v1
-              with:
-                  command: build
-                  args: --release --all-features
-
-            - name: Cargo Test
-              uses: actions-rs/cargo@v1
-              with:
-                  command: test
-                  args: --profile release
-
-            - name: Basic Testing
-              continue-on-error: true
-              run: |
-                  Start-Process -NoNewWindow ${{ github.workspace }}\target\release\dura.exe serve
-                  Start-Sleep -s 15
-                  ${{ github.workspace }}\target\release\dura.exe kill
-
-            - name: Upload Binary
-              uses: actions/upload-artifact@v2
-              with:
-                  name: dura-windows-x86_64_${{ github.sha }}
-                  path: ${{ github.workspace }}\target\release\dura.exe

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on: [ workflow_call, workflow_dispatch, push, pull_request ]
 
 jobs:
   build:
-    name: build-linux
+    name: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,7 +98,7 @@ impl Config {
     }
 
     pub fn create_dir(path: &Path) {
-        path.parent().map(|dir| create_dir_all(dir).unwrap());
+        if let Some(dir) = path.parent() { create_dir_all(dir).unwrap() }
     }
 
     /// Used by tests to save to a temp dir

--- a/src/database.rs
+++ b/src/database.rs
@@ -53,7 +53,7 @@ impl RuntimeLock {
     }
 
     pub fn create_dir(path: &Path) {
-        path.parent().map(|dir| create_dir_all(dir).unwrap());
+        if let Some(dir) = path.parent() { create_dir_all(dir).unwrap() }
     }
 
     /// Used by tests to save to a temp dir

--- a/src/git_repo_iter.rs
+++ b/src/git_repo_iter.rs
@@ -85,7 +85,7 @@ impl<'a> GitRepoIter<'a> {
                         if let Some(dir_iter) = dir_iter_opt {
                             // clone because we're going from more global to less global scope
                             self.sub_iter
-                                .push((Rc::new(path), Rc::clone(&watch_config), dir_iter));
+                                .push((Rc::new(path), Rc::clone(watch_config), dir_iter));
                         }
                         CallState::Recurse
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::fs::OpenOptions;
 use std::path::Path;
 
-use clap::{arg, App, AppSettings, Arg, Values};
+use clap::{arg, App, AppSettings, Arg};
 use dura::config::{Config, WatchConfig};
 use dura::database::RuntimeLock;
 use dura::logger::NestedJsonLayer;
@@ -130,12 +130,12 @@ async fn main() {
 
             let include = arg_matches
                 .values_of("include")
-                .unwrap_or(Values::default())
+                .unwrap_or_default()
                 .map(|s| s.to_string())
                 .collect::<Vec<String>>();
             let exclude = arg_matches
                 .values_of("exclude")
-                .unwrap_or(Values::default())
+                .unwrap_or_default()
                 .map(|s| s.to_string())
                 .collect::<Vec<String>>();
             let max_depth = arg_matches


### PR DESCRIPTION
Brings us closer to resolving #1.

Fixes all Clippy errors in the code-base and requires Clippy to find no problems for builds to pass.

Also refactors the CI workflow to use a matrix and avoid needing to maintain 3 separate near-identical jobs. 