### PR TITLE
refactor: mildly improve error handling

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -100,7 +100,7 @@ impl Config {
     pub fn create_dir(path: &Path) {
         if let Some(dir) = path.parent() {
             create_dir_all(dir)
-                .expect(format!("Failed to create directory at `{}`", dir.display()).as_str())
+                .unwrap_or_else(|_| panic!("Failed to create directory at `{}`", dir.display()))
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,7 +100,10 @@ impl Config {
     pub fn create_dir(path: &Path) {
         if let Some(dir) = path.parent() {
             create_dir_all(dir)
-                .unwrap_or_else(|_| panic!("Failed to create directory at `{}`", dir.display()))
+                .unwrap_or_else(|_| panic!("Failed to create directory at `{}`.\
+                    Dura stores its configuration in `{}/config.toml`, \
+                    where you can instruct dura to watch patterns of Git repositories, among other things. \
+                    See https://github.com/tkellogg/dura for more information.", dir.display(), path.display()))
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,10 +98,13 @@ impl Config {
     }
 
     pub fn create_dir(path: &Path) {
-        if let Some(dir) = path.parent() { create_dir_all(dir).unwrap() }
+        if let Some(dir) = path.parent() {
+            create_dir_all(dir)
+                .expect(format!("Failed to create directory at `{}`", dir.display()).as_str())
+        }
     }
 
-    /// Used by tests to save to a temp dir
+    /// Attempts to create parent dirs, serialize `self` as TOML and write to disk.
     pub fn save_to_path(&self, path: &Path) {
         Self::create_dir(path);
 
@@ -110,7 +113,7 @@ impl Config {
             Err(e) => {
                 println!("Unexpected error when deserializing config: {}", e);
                 return;
-            },
+            }
         };
 
         match fs::write(path, config_string) {
@@ -121,7 +124,7 @@ impl Config {
 
     pub fn set_watch(&mut self, path: String, cfg: WatchConfig) {
         let abs_path = fs::canonicalize(path).expect("The provided path is not a directory");
-        let abs_path = abs_path.to_str().unwrap();
+        let abs_path = abs_path.to_str().expect("The provided path is not valid unicode");
 
         if self.repos.contains_key(abs_path) {
             println!("{} is already being watched", abs_path)
@@ -133,7 +136,7 @@ impl Config {
 
     pub fn set_unwatch(&mut self, path: String) {
         let abs_path = fs::canonicalize(path).expect("The provided path is not a directory");
-        let abs_path = abs_path.to_str().unwrap().to_string();
+        let abs_path = abs_path.to_str().expect("The provided path is not valid unicode").to_string();
 
         match self.repos.remove(&abs_path) {
             Some(_) => println!("Stopped watching {}", abs_path),

--- a/src/database.rs
+++ b/src/database.rs
@@ -55,7 +55,9 @@ impl RuntimeLock {
     pub fn create_dir(path: &Path) {
         if let Some(dir) = path.parent() {
             create_dir_all(dir)
-                .unwrap_or_else(|_| panic!("Failed to create directory at `{}`", dir.display()))
+                .unwrap_or_else(|_| panic!("Failed to create directory at `{}`.\
+                    Dura stores its runtime cache in `{}/runtime.db`. \
+                    See https://github.com/tkellogg/dura for more information.", dir.display(), path.display()))
         }
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -53,12 +53,17 @@ impl RuntimeLock {
     }
 
     pub fn create_dir(path: &Path) {
-        if let Some(dir) = path.parent() { create_dir_all(dir).unwrap() }
+        if let Some(dir) = path.parent() {
+            create_dir_all(dir)
+                .expect(format!("Failed to create directory at `{}`", dir.display()).as_str())
+        }
     }
 
-    /// Used by tests to save to a temp dir
+    /// Attempts to create parent dirs, serialize `self` as JSON and write to disk.
     pub fn save_to_path(&self, path: &Path) {
         Self::create_dir(path);
-        fs::write(path, serde_json::to_string(self).unwrap()).unwrap()
+
+        let json = serde_json::to_string(self).unwrap();
+        fs::write(path, json).unwrap()
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -55,7 +55,7 @@ impl RuntimeLock {
     pub fn create_dir(path: &Path) {
         if let Some(dir) = path.parent() {
             create_dir_all(dir)
-                .expect(format!("Failed to create directory at `{}`", dir.display()).as_str())
+                .unwrap_or_else(|_| panic!("Failed to create directory at `{}`", dir.display()))
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::{EnvFilter, Registry};
 
 #[tokio::main]
 async fn main() {
-    let cwd = std::env::current_dir().unwrap();
+    let cwd = std::env::current_dir().expect("Failed to get current directory");
 
     let arg_directory = Arg::new("directory")
         .default_value_os(cwd.as_os_str())
@@ -83,8 +83,8 @@ async fn main() {
         .get_matches();
 
     match matches.subcommand() {
-        Some(("capture", m)) => {
-            let dir = Path::new(m.value_of("directory").unwrap());
+        Some(("capture", arg_matches)) => {
+            let dir = Path::new(arg_matches.value_of("directory").unwrap());
             if let Some(oid) = snapshots::capture(dir).unwrap() {
                 println!("{}", oid);
             }
@@ -164,13 +164,17 @@ async fn main() {
 
 fn watch_dir(path: &std::path::Path, watch_config: WatchConfig) {
     let mut config = Config::load();
-    config.set_watch(path.to_str().unwrap().to_string(), watch_config);
+    let path = path.to_str().expect("The provided path is not valid unicode").to_string();
+
+    config.set_watch(path, watch_config);
     config.save();
 }
 
 fn unwatch_dir(path: &std::path::Path) {
     let mut config = Config::load();
-    config.set_unwatch(path.to_str().unwrap().to_string());
+    let path = path.to_str().expect("The provided path is not valid unicode").to_string();
+
+    config.set_unwatch(path);
     config.save();
 }
 


### PR DESCRIPTION
Replaces some `unwrap` calls with `expect` calls to panic with more user-friendly messages. In the future we could look to implement better error handling, but since this runs as a daemon anyway, fancy error output is a nice-to-have. I think this should be enough to resolve #1.

There are still several `unwraps` in the code that I've chosen to leave as such, as they *should* cause a panic (things like failing to serialize a struct).