### PR TITLE
Show error message on `capture` fail

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,12 @@ jobs:
           command: build
           args: --release --all-features
 
+      - name: Rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --check
+
       - name: Cargo Clippy
         uses: actions-rs/cargo@v1
         with:

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,7 +127,9 @@ impl Config {
 
     pub fn set_watch(&mut self, path: String, cfg: WatchConfig) {
         let abs_path = fs::canonicalize(path).expect("The provided path is not a directory");
-        let abs_path = abs_path.to_str().expect("The provided path is not valid unicode");
+        let abs_path = abs_path
+            .to_str()
+            .expect("The provided path is not valid unicode");
 
         if self.repos.contains_key(abs_path) {
             println!("{} is already being watched", abs_path)
@@ -139,7 +141,10 @@ impl Config {
 
     pub fn set_unwatch(&mut self, path: String) {
         let abs_path = fs::canonicalize(path).expect("The provided path is not a directory");
-        let abs_path = abs_path.to_str().expect("The provided path is not valid unicode").to_string();
+        let abs_path = abs_path
+            .to_str()
+            .expect("The provided path is not valid unicode")
+            .to_string();
 
         match self.repos.remove(&abs_path) {
             Some(_) => println!("Stopped watching {}", abs_path),

--- a/src/database.rs
+++ b/src/database.rs
@@ -54,10 +54,15 @@ impl RuntimeLock {
 
     pub fn create_dir(path: &Path) {
         if let Some(dir) = path.parent() {
-            create_dir_all(dir)
-                .unwrap_or_else(|_| panic!("Failed to create directory at `{}`.\
+            create_dir_all(dir).unwrap_or_else(|_| {
+                panic!(
+                    "Failed to create directory at `{}`.\
                     Dura stores its runtime cache in `{}/runtime.db`. \
-                    See https://github.com/tkellogg/dura for more information.", dir.display(), path.display()))
+                    See https://github.com/tkellogg/dura for more information.",
+                    dir.display(),
+                    path.display()
+                )
+            })
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,10 @@ async fn main() {
 
 fn watch_dir(path: &std::path::Path, watch_config: WatchConfig) {
     let mut config = Config::load();
-    let path = path.to_str().expect("The provided path is not valid unicode").to_string();
+    let path = path
+        .to_str()
+        .expect("The provided path is not valid unicode")
+        .to_string();
 
     config.set_watch(path, watch_config);
     config.save();
@@ -181,7 +184,10 @@ fn watch_dir(path: &std::path::Path, watch_config: WatchConfig) {
 
 fn unwatch_dir(path: &std::path::Path) {
     let mut config = Config::load();
-    let path = path.to_str().expect("The provided path is not valid unicode").to_string();
+    let path = path
+        .to_str()
+        .expect("The provided path is not valid unicode")
+        .to_string();
 
     config.set_unwatch(path);
     config.save();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::fs::OpenOptions;
 use std::path::Path;
+use std::process;
 
 use clap::{arg, App, AppSettings, Arg};
 use dura::config::{Config, WatchConfig};
@@ -85,8 +86,16 @@ async fn main() {
     match matches.subcommand() {
         Some(("capture", arg_matches)) => {
             let dir = Path::new(arg_matches.value_of("directory").unwrap());
-            if let Some(oid) = snapshots::capture(dir).unwrap() {
-                println!("{}", oid);
+            match snapshots::capture(dir) {
+                Ok(oid_opt) => {
+                    if let Some(oid) = oid_opt {
+                        println!("{}", oid);
+                    }
+                }
+                Err(e) => {
+                    println!("Dura capture failed: {}", e);
+                    process::exit(1);
+                }
             }
         }
         Some(("serve", arg_matches)) => {

--- a/tests/startup_test.rs
+++ b/tests/startup_test.rs
@@ -14,7 +14,9 @@ fn start_serve() {
     assert_eq!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(START_TIMEOUT).unwrap());
+    dura.primary
+        .as_ref()
+        .map(|d| d.read_line(START_TIMEOUT).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -33,7 +35,9 @@ fn start_serve_with_null_pid_in_config() {
     assert_ne!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(START_TIMEOUT).unwrap());
+    dura.primary
+        .as_ref()
+        .map(|d| d.read_line(START_TIMEOUT).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -54,7 +58,9 @@ fn start_serve_with_other_pid_in_config() {
     assert_ne!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(START_TIMEOUT).unwrap());
+    dura.primary
+        .as_ref()
+        .map(|d| d.read_line(START_TIMEOUT).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();
@@ -73,7 +79,9 @@ fn start_serve_with_invalid_json() {
     assert_eq!(None, dura.get_runtime_lock());
 
     dura.start_async(&["serve"], true);
-    dura.primary.as_ref().map(|d| d.read_line(START_TIMEOUT).unwrap());
+    dura.primary
+        .as_ref()
+        .map(|d| d.read_line(START_TIMEOUT).unwrap());
 
     assert_ne!(None, dura.pid(true));
     let runtime_lock = dura.get_runtime_lock();

--- a/tests/util/daemon.rs
+++ b/tests/util/daemon.rs
@@ -1,6 +1,6 @@
-use std::io::{BufReader, BufRead};
+use std::io::{BufRead, BufReader};
 use std::process::{Child, ChildStdout};
-use std::sync::mpsc::{Receiver, channel};
+use std::sync::mpsc::{channel, Receiver};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -10,10 +10,10 @@ use std::time::Duration;
 /// tests more reliable when they dispatch asynchronously to `dura serve`. However, nothing abot
 /// this is intended to be specific to dura.
 pub struct Daemon {
-   mailbox: Receiver<Option<String>>, 
-   pub child: Child,
-   /// Signals to kill daemon thread if this goes <= 0, like a CountDownLatch
-   kill_sign: Arc<Mutex<i32>>,
+    mailbox: Receiver<Option<String>>,
+    pub child: Child,
+    /// Signals to kill daemon thread if this goes <= 0, like a CountDownLatch
+    kill_sign: Arc<Mutex<i32>>,
 }
 
 impl Daemon {
@@ -21,8 +21,11 @@ impl Daemon {
         let kill_sign = Arc::new(Mutex::new(1));
         Self {
             mailbox: Self::attach(
-               child.stdout.take().expect("Configure Command to capture stdout"),
-               Arc::clone(&kill_sign),
+                child
+                    .stdout
+                    .take()
+                    .expect("Configure Command to capture stdout"),
+                Arc::clone(&kill_sign),
             ),
             child,
             kill_sign,
@@ -64,7 +67,9 @@ impl Daemon {
 
     /// Read a line from the child process, waiting at most timeout_secs.
     pub fn read_line(&self, timeout_secs: u64) -> Option<String> {
-        self.mailbox.recv_timeout(Duration::from_secs(timeout_secs)).unwrap()
+        self.mailbox
+            .recv_timeout(Duration::from_secs(timeout_secs))
+            .unwrap()
     }
 
     pub fn kill(&mut self) {

--- a/tests/util/dura.rs
+++ b/tests/util/dura.rs
@@ -1,12 +1,13 @@
 use std::{
-    ops, path, thread, time,
-    process::{Command, Stdio},
     collections::HashSet,
+    ops, path,
+    process::{Command, Stdio},
+    thread, time,
 };
 
+use crate::util::daemon::Daemon;
 use dura::config::Config;
 use dura::database::RuntimeLock;
-use crate::util::daemon::Daemon;
 
 /// Utility to start dura asynchronously (e.g. dura serve) and kill the process when this goes out
 /// of scope. This helps us do end-to-end tests where we invoke the executable, possibly multiple

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,6 +1,6 @@
 // Not every test module -- which are compiled at seperate binaries, use every function, causing dead_code to be emitted.
 #![allow(dead_code)]
 
+pub mod daemon;
 pub mod dura;
 pub mod git_repo;
-pub mod daemon;


### PR DESCRIPTION
Handle and print more readable error messages on `capture` fail rather than panicking.