### PR TITLE
chore: rewrite comment on dura config home

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -60,8 +60,13 @@ impl Config {
         Self::get_dura_config_home().join("config.toml")
     }
 
-    /// Location of all config & database files. By default this is ~/.config/dura but can be
-    /// overridden by setting DURA_CONFIG_HOME environment variable.
+    /// Location of all config & database files. By default
+    ///
+    /// Linux   :   $XDG_CONFIG_HOME/dura or $HOME/.config/dura
+    /// macOS   :   $HOME/Library/Application Support
+    /// Windows :   {FOLDERID_RoamingAppData}/dura
+    ///
+    /// This can be overridden by setting DURA_CONFIG_HOME environment variable.
     fn get_dura_config_home() -> PathBuf {
         // The environment variable lets us run tests independently, but I'm sure someone will come
         // up with another reason to use it.
@@ -147,7 +152,9 @@ impl Config {
             .to_string();
 
         match self.repos.remove(&abs_path) {
-            Some(_) => println!("Stopped watching {}", abs_path),
+            Some(_) => {
+                println!("Stopped watching {}", abs_path);
+            }
             None => println!("{} is not being watched", abs_path),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,11 +60,11 @@ impl Config {
         Self::get_dura_config_home().join("config.toml")
     }
 
-    /// Location of all config & database files. By default
+    /// Location of all config. By default
     ///
     /// Linux   :   $XDG_CONFIG_HOME/dura or $HOME/.config/dura
     /// macOS   :   $HOME/Library/Application Support
-    /// Windows :   {FOLDERID_RoamingAppData}/dura
+    /// Windows :   %AppData%\Roaming\dura
     ///
     /// This can be overridden by setting DURA_CONFIG_HOME environment variable.
     fn get_dura_config_home() -> PathBuf {

--- a/src/database.rs
+++ b/src/database.rs
@@ -19,8 +19,13 @@ impl RuntimeLock {
         Self::get_dura_cache_home().join("runtime.db")
     }
 
-    /// Location of all config & database files. By default this is ~/.cache/dura but can be
-    /// overridden by setting DURA_CACHE_HOME environment variable.
+    /// Location of all database files. By default
+    ///
+    /// Linux   :   $XDG_CACHE_HOME/dura or $HOME/.cache/dura
+    /// macOS   :   $HOME/Library/Caches
+    /// Windows :   %AppData%\Local\dura
+    ///
+    /// This can be overridden by setting DURA_CACHE_HOME environment variable.
     fn get_dura_cache_home() -> PathBuf {
         // The environment variable lets us run tests independently, but I'm sure someone will come
         // up with another reason to use it.


### PR DESCRIPTION
`dirs::config_dir()` is not always at `~/.config`. Re-written the comment for dura config home to describe this better.

See for reference https://docs.rs/dirs/4.0.0/dirs/fn.config_dir.html