### PR TITLE
Update for new install way!

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ to develop:
 nix develop github:tkellogg/dura
 ```
 
+### Cargo Install
+1. Install Cargo
+2. Run `cargo install dura`
+
 ### By Source
 
 1. Install Rust (e.g., `brew install rustup && brew install rust`)


### PR DESCRIPTION
I published dura to crates.io.
Now can Install with `cargo install dura`!