### PR TITLE
Added metrics formatter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,11 @@
 2. Add tests, if possible
     * [`end_to_end_test.rs`](https://github.com/tkellogg/dura/blob/master/tests/end_to_end_test.rs) is a good place to test out new functionality, and the test code reads fairly well.
     * Unit tests are preferred, when feasible. They go inside source files.
-3. Explain the behavior as best as possible. Things like screenshots and GIFs can be helpful when it's visual.
-4. Breathe deep. Smell the fresh clean air.
+3. Run `$ ./scripts/pre-commit.sh` before pushing. This does almost everything that happens in CI, just faster.
+4. Explain the behavior as best as possible. Things like screenshots and GIFs can be helpful when it's visual.
+5. Breathe deep. Smell the fresh clean air.
 
-I try to get to PRs within a day. I'm usually quicker than that, but sometimes things slide through the cracks.
+We try to get to PRs within a day. We're usually quicker than that, but sometimes things slide through the cracks.
 
 Oh! And please be kind. We're all here because we want to help other people. Please remember that.
 
@@ -19,5 +20,23 @@ Oh! And please be kind. We're all here because we want to help other people. Ple
 * All `stdout` is routed through the logger and is JSON.
 * Messages to the user should be on `stderr` and are plain text (e.g. can't take a lock)
 * Use serialized structs to write JSON logs, so that the structure remains mostly backward compatible. Try not to rename fields, in case someone has written scripts against it.
+
+
+## Unit tests vs Integration tests
+For the purposes of this project, "integration tests" use the filesystem. The [official Rust recommendation](https://doc.rust-lang.org/book/ch11-03-test-organization.html) 
+is:
+
+* **Unit tests** go inline inside source files, in a `#[cfg(test)]` module. Structure your code so that
+  you can use these to test private functions without using the external dependencies like the 
+  filesystem.
+* **Integration tests** go "externally", in the `/tests` folder. Use the utilities in `tests/util` to 
+  work with external dependencies easier.
+  * `git_repo` — makes it easy to work with Git repositories in a temp directory. It does it in a way
+    that tests can continue to run in parallel without interfering with each other.
+  * `dura` — makes it easy to call the real `dura` executable in a sub-process. This makes it 
+    possible to run tests in parallel by setting environment varibales only for the sub-process 
+    (e.g. `$DURA_HOME`). It also uses the `util::daemon` module to facilitate working with `dura serve`
+    by allowing you to make a blocking call to `read_line` to wait the minimum amount of time for
+    an activity to happen (like startup or snapshots).
 
 

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# This script is intended to be run before committing. It represents what's don in CI anyway, 
+# but should reduce the frustration of getting your commits rejected. This isn't identical to 
+# what happens in CI, it's a much faster version, it does everything in DEBUG.
+
+# Failed commands should cause the entire script to fail immediately
+set -e
+
+echo "################################"
+echo "### cargo test"
+echo "################################"
+cargo test
+
+echo "################################"
+echo "### cargo clippy"
+echo "################################"
+cargo clippy -- -D warnings
+
+echo "################################"
+echo "### cargo fmt"
+echo "################################"
+# This doesn't fail, it just leaves files changed
+cargo fmt
+if [[ ! -z "$(git diff-index --name-only HEAD --)" ]]; then
+  echo "Error: Git changes present, maybe from 'cargo fmt', consider committing"
+  exit 1
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod log;
 pub mod logger;
 pub mod poller;
 pub mod snapshots;
+pub mod metrics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,6 @@ pub mod database;
 pub mod git_repo_iter;
 pub mod log;
 pub mod logger;
+pub mod metrics;
 pub mod poller;
 pub mod snapshots;
-pub mod metrics;

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,13 +196,13 @@ async fn main() {
         Some(("metrics", arg_matches)) => {
             let mut input: Box<dyn Read> = match arg_matches.value_of("input") {
                 Some(input) => {
-                    Box::new(File::open(input).expect(format!("Couldn't open '{}'", input).as_str()))
+                    Box::new(File::open(input).unwrap_or_else(|_| panic!("Couldn't open '{}'", input)))
                 }
                 None => Box::new(BufReader::new(stdin()))
             };
             let mut output: Box<dyn Write> = match arg_matches.value_of("output") {
                 Some(output) => {
-                    Box::new(File::open(output).expect(format!("Couldn't open '{}'", output).as_str()))
+                    Box::new(File::open(output).unwrap_or_else(|_| panic!("Couldn't open '{}'", output)))
                 }
                 None => Box::new(BufWriter::new(stdout()))
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,7 +207,7 @@ async fn main() {
                 None => Box::new(BufWriter::new(stdout())),
             };
             if let Err(e) = metrics::get_snapshot_metrics(&mut input, &mut output) {
-                eprintln("Failed: {}", e);
+                eprintln!("Failed: {}", e);
                 process::exit(1);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use std::fs::{OpenOptions, File};
+use std::fs::{File, OpenOptions};
+use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
 use std::path::Path;
 use std::process;
-use std::io::{Read, Write, stdin, stdout, BufReader, BufWriter};
 
 use clap::{
     arg, crate_authors, crate_description, crate_name, crate_version, App, AppSettings, Arg,
@@ -195,16 +195,16 @@ async fn main() {
         }
         Some(("metrics", arg_matches)) => {
             let mut input: Box<dyn Read> = match arg_matches.value_of("input") {
-                Some(input) => {
-                    Box::new(File::open(input).unwrap_or_else(|_| panic!("Couldn't open '{}'", input)))
-                }
-                None => Box::new(BufReader::new(stdin()))
+                Some(input) => Box::new(
+                    File::open(input).unwrap_or_else(|_| panic!("Couldn't open '{}'", input)),
+                ),
+                None => Box::new(BufReader::new(stdin())),
             };
             let mut output: Box<dyn Write> = match arg_matches.value_of("output") {
-                Some(output) => {
-                    Box::new(File::open(output).unwrap_or_else(|_| panic!("Couldn't open '{}'", output)))
-                }
-                None => Box::new(BufWriter::new(stdout()))
+                Some(output) => Box::new(
+                    File::open(output).unwrap_or_else(|_| panic!("Couldn't open '{}'", output)),
+                ),
+                None => Box::new(BufWriter::new(stdout())),
             };
             metrics::get_snapshot_metrics(&mut input, &mut output).unwrap();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,10 @@ async fn main() {
                 ),
                 None => Box::new(BufWriter::new(stdout())),
             };
-            metrics::get_snapshot_metrics(&mut input, &mut output).unwrap();
+            if let Err(e) = metrics::get_snapshot_metrics(&mut input, &mut output) {
+                eprintln("Failed: {}", e);
+                process::exit(1);
+            }
         }
         _ => unreachable!(),
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -82,11 +82,10 @@ fn scrape_git(
     repo_cache: &mut HashMap<String, Rc<Repository>>,
 ) -> Result<(), git2::Error> {
     if let Some(repo_path_value) = value.get("repo") {
-        // unwrap_or - the default value isn't really valid, but it's valid enough to pass into
-        // Repository::open(), which will generate a git2::Error. I'm not sure if this is a good
-        // practice, but this bogus return value allows us to avoid panicing. If it's not a real
-        // path, then it won't be found in repo_cache either.
-        let repo_path = repo_path_value.as_str().unwrap_or("");
+        let repo_path = match repo_path_value.as_str() {
+            Some(x) => Ok(x),
+            None => Err(git2::Error::from_str(format!("Couldn't find 'repo' in JSON").as_str()))
+        }?;
         let repo = match repo_cache.get(repo_path) {
             Some(repo) => Rc::clone(repo),
             None => {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,132 @@
+use std::io;
+use std::io::{BufRead, Write};
+use git2::{Oid, Repository};
+use serde_json::{Value, Number, json};
+use serde_json::map::Map;
+use serde_json::value::from_value;
+use crate::log::Operation;
+
+type FlexResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+/// Reads an input stream that contains dura logs and enriches them with more analytics-ready info
+/// like number of insertions & deletions. The result is written back out to an output stream.
+pub fn get_snapshot_metrics(input: &mut dyn io::Read, output: &mut dyn io::Write) -> FlexResult<()> {
+    let mut reader = io::BufReader::new(input);
+    let mut writer = io::BufWriter::new(output);
+    let mut line: u64 = 0; // for printing better error messages
+    loop {
+        line += 1;
+        let mut input_line = String::new();
+        if reader.read_line(&mut input_line)? == 0 {
+            return Ok(());
+        }
+        match scrape_log(input_line) {
+            Ok(Some(mut output)) => {
+                scrape_git(&mut output)?;
+                writeln!(&mut writer, "{}", output)?;
+            }
+            Ok(None) => {},
+            // Seems like a good way to report errors, idk...
+            Err(e) => eprintln!("line {}: {}", line, e),
+        }
+    }
+}
+
+/// Scrape information out of the snapshot log.
+fn scrape_log(line: String) -> serde_json::Result<Option<Value>> {
+    let input_val: Value = serde_json::from_str(line.as_str())?;
+    let mut output_val = Value::Object(Map::new());
+
+    if let Some(t) = input_val.get("time") {
+        output_val["time"] = t.clone();
+    }
+
+    if let Some(op_value) = input_val.get("fields").and_then(|f| f.get("operation")) {
+        match from_value(op_value.clone())? {
+            Operation::Snapshot {repo, op: Some(op), error: _, latency} => {
+                output_val["repo"] = Value::String(repo);
+                if let Some(latency) = Number::from_f64(latency as f64) {
+                    output_val["latency"] = Value::Number(latency);
+                }
+                output_val["dura_branch"] = Value::String(op.dura_branch);
+                output_val["commit_hash"] = Value::String(op.commit_hash);
+                output_val["base_hash"] = Value::String(op.base_hash);
+            }
+            _ => return Ok(None)
+        }
+    } else {
+        return Ok(None);
+    }
+
+    Ok(Some(output_val))
+}
+
+/// Use the info captured from scrape_log to open a repo and capture information about the commit
+fn scrape_git(value: &mut Value) -> Result<(), git2::Error> {
+    if let Some(repo_path) = value.get("repo") {
+        let repo = Repository::open(repo_path.as_str().unwrap_or(""))?;
+        let commit_opt = value.get("commit_hash")
+            .and_then(|c| c.as_str())
+            .and_then(|c| Oid::from_str(c).ok())
+            .and_then(|c| repo.find_commit(c).ok());
+        let parent_commit = commit_opt.as_ref()
+            .and_then(|c| c.parents().last());
+        if let (Some(commit), Some(parent)) = (commit_opt, parent_commit) {
+            let diff = repo.diff_tree_to_tree(Some(&parent.tree()?), Some(&commit.tree()?), None)?;
+            let stats = diff.stats()?;
+            value["files_changed"] = json!(stats.files_changed());
+            value["insertions"] = json!(stats.insertions());
+            value["deletions"] = json!(stats.deletions());
+        };
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::metrics::scrape_log;
+
+    #[test]
+    fn scrape_log_happy_path() {
+        // broken up into multiple lines to satisfy style checker, but serde_json will handle it
+        // fine
+        let line = r#"{"target":"dura::poller","file":"src/poller.rs",
+            "name":"event src/poller.rs:70","level":"Level(Info)",
+            "fields":{
+                "message":"info_operation","operation":{"Snapshot":{
+                    "error":null,"latency":0.00988253,"op":{
+                        "base_hash":"3e8e8c99b5434e726b13f56ba00d139bab57d5eb",
+                        "commit_hash":"3423d21a2937d95119982395bc1281d3d8ebe3b6",
+                        "dura_branch":"dura/3e8e8c99b5434e726b13f56ba00d139bab57d5eb"
+                    },
+                    "repo":"/Users/timkellogg/code/dura"}
+                }
+            },"time":"2022-01-14T01:49:51.638031+00:00"
+        }"#;
+
+        let output = scrape_log(line.to_string()).unwrap().unwrap();
+
+        assert_eq!(output["time"].as_str(), Some("2022-01-14T01:49:51.638031+00:00"));
+        assert_eq!(output["repo"].as_str(), Some("/Users/timkellogg/code/dura"));
+        assert_eq!(output["dura_branch"].as_str(), Some("dura/3e8e8c99b5434e726b13f56ba00d139bab57d5eb"));
+        assert_eq!(output["commit_hash"].as_str(), Some("3423d21a2937d95119982395bc1281d3d8ebe3b6"));
+        assert_eq!(output["base_hash"].as_str(), Some("3e8e8c99b5434e726b13f56ba00d139bab57d5eb"));
+        let latency = output["latency"].as_f64().unwrap();
+        assert!(latency < (0.00988253 + f32::EPSILON).into());
+        assert!(latency > (0.00988253 - f32::EPSILON).into());
+    }
+
+    #[test]
+    fn scrape_log_no_snapshot() {
+        // broken up into multiple lines to satisfy style checker, but serde_json will handle it
+        // fine
+        let line = r#"{"target":"dura","file":"src/main.rs","name":"event src/main.rs:96",
+            "level":"Level(Info)","fields":{"pid":5416},
+            "time":"2022-01-14T01:45:37.469819+00:00"}"#;
+
+        let output = scrape_log(line.to_string()).unwrap();
+
+        assert_eq!(output, None);
+    }
+}
+

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -82,6 +82,10 @@ fn scrape_git(
     repo_cache: &mut HashMap<String, Rc<Repository>>,
 ) -> Result<(), git2::Error> {
     if let Some(repo_path_value) = value.get("repo") {
+        // unwrap_or - the default value isn't really valid, but it's valid enough to pass into
+        // Repository::open(), which will generate a git2::Error. I'm not sure if this is a good
+        // practice, but this bogus return value allows us to avoid panicing. If it's not a real
+        // path, then it won't be found in repo_cache either.
         let repo_path = repo_path_value.as_str().unwrap_or("");
         let repo = match repo_cache.get(repo_path) {
             Some(repo) => Rc::clone(repo),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -84,7 +84,9 @@ fn scrape_git(
     if let Some(repo_path_value) = value.get("repo") {
         let repo_path = match repo_path_value.as_str() {
             Some(x) => Ok(x),
-            None => Err(git2::Error::from_str(format!("Couldn't find 'repo' in JSON").as_str()))
+            None => Err(git2::Error::from_str(
+                format!("Couldn't find 'repo' in JSON").as_str(),
+            )),
         }?;
         let repo = match repo_cache.get(repo_path) {
             Some(repo) => Rc::clone(repo),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -84,9 +84,7 @@ fn scrape_git(
     if let Some(repo_path_value) = value.get("repo") {
         let repo_path = match repo_path_value.as_str() {
             Some(x) => Ok(x),
-            None => Err(git2::Error::from_str(
-                format!("Couldn't find 'repo' in JSON").as_str(),
-            )),
+            None => Err(git2::Error::from_str("Couldn't find 'repo' in JSON")),
         }?;
         let repo = match repo_cache.get(repo_path) {
             Some(repo) => Rc::clone(repo),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -73,7 +73,7 @@ fn scrape_git(value: &mut Value, repo_cache: &mut HashMap<String, Rc<Repository>
     if let Some(repo_path_value) = value.get("repo") {
         let repo_path = repo_path_value.as_str().unwrap_or("");
         let repo = match repo_cache.get(repo_path) {
-            Some(repo) => Rc::clone(&repo),
+            Some(repo) => Rc::clone(repo),
             None => {
                 let repo = Rc::new(Repository::open(repo_path)?);
                 repo_cache.insert(repo_path.to_string(), Rc::clone(&repo));

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -77,6 +77,12 @@ fn scrape_git(value: &mut Value) -> Result<(), git2::Error> {
             value["files_changed"] = json!(stats.files_changed());
             value["insertions"] = json!(stats.insertions());
             value["deletions"] = json!(stats.deletions());
+
+            let files: Vec<_> = diff.deltas()
+                .flat_map(|d| d.new_file().path())
+                .map(|p| p.to_str())
+                .collect();
+            value["files_changed"] = json!(files);
         };
     }
     Ok(())


### PR DESCRIPTION
This adds a `dura metrics --input {log file}` subcommand that captures the logs, filters it to just snapshots, and enriches it with useful Git info that's not in the logs:

* Number of lines `+`/`-`
* List of files changed

Sample output:

```
{"base_hash":"a799ffdedac9bfadd249de2f81f835a3fd80154c","commit_hash":"eff2ad3ed90e99603fc4ab6e64a7634bd6f0778d","deletions":2,"dura_branch":"dura/a799ffdedac9bfadd249de2f81f835a3fd80154c","files_changed":["src/main.rs"],"insertions":2,"latency":0.017979679629206657,"num_files_changed":1,"repo":"/Users/timkellogg/code/dura","time":"2022-01-23T07:13:34.805380+00:00"}
{"base_hash":"0c8340fa18cee96aba22629ef53b0412b3165bad","commit_hash":"c1b6c692646509ad8ddf389fb61aa02588dba706","deletions":1,"dura_branch":"dura/0c8340fa18cee96aba22629ef53b0412b3165bad","files_changed":["src/metrics.rs"],"insertions":1,"latency":0.013224250636994839,"num_files_changed":1,"repo":"/Users/timkellogg/code/dura","time":"2022-01-23T07:17:53.878017+00:00"}
```

I have an idea that I want to look into. I think that there's a pattern with how I write Rust code. I haven't gotten a chance to visualize yet, but I think I'll see a mountain of code additions followed by a long trickle of small changes. If true, I think this would be a visualization of my fight with the Rust compiler. I might write a blog post about using Dura this way.