### PR TITLE
Optimization: Check file timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,17 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,15 +100,6 @@ name = "clap_lex"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -406,15 +386,6 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1007,12 +978,6 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -88,18 +94,27 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -131,6 +146,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.4",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,8 +180,9 @@ dependencies = [
 
 [[package]]
 name = "dura"
-version = "0.2.0"
+version = "0.2.0-dev"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "dirs",
@@ -167,6 +196,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]
@@ -199,6 +229,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+
+[[package]]
+name = "futures-task"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+
+[[package]]
+name = "futures-util"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
 dependencies = [
  "bitflags",
  "libc",
@@ -226,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hdrhistogram"
@@ -266,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -306,15 +413,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.14.0+1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
 dependencies = [
  "cc",
  "libc",
@@ -352,10 +459,11 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -476,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openssl-probe"
@@ -504,9 +612,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "parking_lot"
@@ -516,7 +621,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.4",
 ]
 
 [[package]]
@@ -534,6 +649,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot_core"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,10 +674,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -628,6 +786,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,21 +833,25 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "0.5.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
 dependencies = [
+ "dashmap",
+ "futures",
  "lazy_static",
- "parking_lot",
+ "log",
+ "parking_lot 0.12.1",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "0.5.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
 dependencies = [
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -702,6 +873,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -752,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thread_local"
@@ -803,7 +983,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
@@ -931,6 +1111,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,3 +1163,60 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,10 @@ repository = "https://github.com/tkellogg/dura/"
 documentation = "https://github.com/tkellogg/dura/blob/master/README.md"
 
 [dependencies]
+anyhow = "1.0.66"
 clap = { version = "3.1.6", features = ["cargo"] }
-git2 = "0.13"
+git2 = "0.15"
+hdrhistogram = "7.5.2"
 dirs = "4.0.0"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
@@ -20,8 +22,8 @@ chrono = "0.4"
 toml = "0.5.8"
 tracing = { version = "0.1.5"}
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
-hdrhistogram = "7.5.2"
+walkdir = "2.3.2"
 
 [dev-dependencies]
 tempfile = "3.2.0"
-serial_test = "0.5.1"
+serial_test = "0.9.0"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -14,7 +14,7 @@ cargo test
 echo "################################"
 echo "### cargo clippy"
 echo "################################"
-cargo clippy -- -D warnings
+cargo clippy --all-targets --all-features -- -D warnings
 
 echo "################################"
 echo "### cargo fmt"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,6 @@ pub mod git_repo_iter;
 pub mod log;
 pub mod logger;
 pub mod metrics;
+pub mod poll_guard;
 pub mod poller;
 pub mod snapshots;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use clap::builder::IntoResettable;
 use clap::{
     arg, crate_authors, crate_description, crate_name, crate_version, value_parser, Arg, Command,
 };
+use tracing::info;
 use dura::config::{Config, WatchConfig};
 use dura::database::RuntimeLock;
 use dura::logger::NestedJsonLayer;
@@ -164,6 +165,7 @@ async fn main() {
                 }
             }
 
+            info!("Started serving with dura v{}", crate_version!());
             poller::start().await;
         }
         Some(("watch", arg_matches)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,13 @@ use clap::builder::IntoResettable;
 use clap::{
     arg, crate_authors, crate_description, crate_name, crate_version, value_parser, Arg, Command,
 };
-use tracing::info;
 use dura::config::{Config, WatchConfig};
 use dura::database::RuntimeLock;
 use dura::logger::NestedJsonLayer;
 use dura::metrics;
 use dura::poller;
 use dura::snapshots;
+use tracing::info;
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};

--- a/src/poll_guard.rs
+++ b/src/poll_guard.rs
@@ -1,0 +1,109 @@
+use git2::{BranchType, Commit, Repository};
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+use std::ops::Add;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use anyhow::Result;
+use walkdir::{DirEntry, WalkDir};
+
+/// OPTIMIZATION for checking for changes
+///
+/// Provides a function, dir_changed, that is a much faster way to detect if any files in
+/// a repository have changed, vs the naive method of trying to commit the repo. This peeks at
+/// the file timestamp, which is typically cached in memory. The previous way to do it was to
+/// let Git2 make a commit, which triggered a whole lot of I/O and hashing.
+pub struct PollGuard {
+    git_cache: HashMap<PathBuf, Repository>,
+}
+
+impl PollGuard {
+    pub fn new() -> Self {
+        Self {
+            git_cache: Default::default(),
+        }
+    }
+
+    pub fn dir_changed(&mut self, dir: &Path) -> bool {
+        let watermark = match self.get_watermark(dir) {
+            Ok(watermark) => watermark,
+            // True because we want to turn off this optimization
+            Err(_) => return true,
+        };
+
+        fn compare_times(modified: SystemTime, watermark: SystemTime) -> Result<bool> {
+            let duration = modified.duration_since(watermark)?;
+            Ok(duration.as_secs_f32() > 1.0)
+        }
+
+        fn get_file_time(entry: walkdir::Result<DirEntry>) -> Result<SystemTime> {
+            Ok(entry?.metadata()?.modified()?)
+        }
+
+        for entry in WalkDir::new(dir) {
+            let repo = self.git_cache.get(dir).unwrap();
+            if let Ok(ref repo_path) = entry {
+                if repo.is_path_ignored(repo_path.path()).unwrap_or(false) {
+                    continue;
+                }
+            }
+
+            if let Ok(modified) = get_file_time(entry) {
+                if compare_times(modified, watermark).unwrap_or(false) {
+                    dbg!(modified, watermark);
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Find the last known commit timestamp
+    fn get_watermark(&mut self, path: &Path) -> Result<SystemTime> {
+        let repo: &Repository = match self.git_cache.get(path) {
+            Some(found) => found,
+            None => {
+                let new = Repository::open(path)?;
+                self.git_cache.insert(path.to_path_buf(), new);
+                self.git_cache.get(path).unwrap()
+            }
+        };
+
+        fn get_time(commit: &Commit) -> SystemTime {
+            SystemTime::UNIX_EPOCH.add(Duration::from_secs(commit.time().seconds() as u64))
+        }
+
+        fn get_dura_time(head: &Commit, repo: &Repository) -> Result<SystemTime> {
+            let branch_name = format!("dura/{}", head.id());
+            let ret = repo
+                .find_branch(&branch_name, BranchType::Local)?
+                .get()
+                .peel_to_commit()?;
+            Ok(get_time(&ret))
+        }
+
+        // get commit time and fallback to time of HEAD
+        let head = repo.head()?.peel_to_commit()?;
+        get_dura_time(&head, repo).or_else(|_| Ok(get_time(&head)))
+    }
+}
+
+/// Implemented manually because Repository doesn't implement it
+impl Debug for PollGuard {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("PollGuard { ")?;
+        for dir in self.git_cache.keys() {
+            f.write_str(dir.to_str().unwrap_or("n/a"))?;
+            f.write_str(", ")?;
+        }
+        f.write_str(" }")?;
+        Ok(())
+    }
+}
+
+impl Default for PollGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/poll_guard.rs
+++ b/src/poll_guard.rs
@@ -43,12 +43,6 @@ impl PollGuard {
         }
 
         for entry in WalkDir::new(dir) {
-            if let (Ok(ref repo_path), Some(repo)) = (&entry, self.git_cache.get(dir)) {
-                if repo.is_path_ignored(repo_path.path()).unwrap_or(false) {
-                    continue;
-                }
-            }
-
             if let Ok(modified) = get_file_time(entry) {
                 if compare_times(modified, watermark).unwrap_or(false) {
                     dbg!(modified, watermark);

--- a/src/poll_guard.rs
+++ b/src/poll_guard.rs
@@ -85,7 +85,7 @@ impl PollGuard {
 
         // get commit time and fallback to time of HEAD
         let head = repo.head()?.peel_to_commit()?;
-        get_dura_time(&head, repo).or_else(|_| Ok(get_time(&head)))
+        Ok(get_dura_time(&head, repo).unwrap_or_else(|_| get_time(&head)))
     }
 }
 

--- a/tests/poll_guard_test.rs
+++ b/tests/poll_guard_test.rs
@@ -14,11 +14,11 @@ fn changed_file() {
     repo.commit_all();
 
     let mut pg = PollGuard::new();
-    assert_eq!(pg.dir_changed(repo.dir.as_path()), false);
+    assert!(!pg.dir_changed(repo.dir.as_path()));
 
     sleep(Duration::from_secs_f64(1.5));
     repo.change_file("foo.txt");
-    assert_eq!(pg.dir_changed(repo.dir.as_path()), true);
+    assert!(pg.dir_changed(repo.dir.as_path()));
 }
 
 /// Changing a branch shouldn't trigger the slow process
@@ -31,12 +31,12 @@ fn branch_changed() {
     repo.commit_all();
 
     let mut pg = PollGuard::new();
-    assert_eq!(pg.dir_changed(repo.dir.as_path()), false);
+    assert!(!pg.dir_changed(repo.dir.as_path()));
 
     sleep(Duration::from_secs_f64(1.5));
     repo.git(&["checkout", "-b", "new-branch"])
         .expect("checkout failed");
-    assert_eq!(pg.dir_changed(repo.dir.as_path()), false);
+    assert!(!pg.dir_changed(repo.dir.as_path()));
 }
 
 #[test]
@@ -48,17 +48,17 @@ fn file_changed_after_snapshot() {
     repo.commit_all();
 
     let mut pg = PollGuard::new();
-    assert_eq!(pg.dir_changed(repo.dir.as_path()), false);
+    assert!(!pg.dir_changed(repo.dir.as_path()));
 
     sleep(Duration::from_secs_f64(1.5));
     repo.change_file("foo.txt");
-    assert_eq!(pg.dir_changed(repo.dir.as_path()), true);
+    assert!(pg.dir_changed(repo.dir.as_path()));
 
     sleep(Duration::from_secs_f64(1.5));
     snapshots::capture(repo.dir.as_path()).expect("snapshot failed");
-    assert_eq!(pg.dir_changed(repo.dir.as_path()), false);
+    assert!(!pg.dir_changed(repo.dir.as_path()));
 
     sleep(Duration::from_secs_f64(1.5));
     repo.change_file("foo.txt");
-    assert_eq!(pg.dir_changed(repo.dir.as_path()), true);
+    assert!(pg.dir_changed(repo.dir.as_path()));
 }

--- a/tests/poll_guard_test.rs
+++ b/tests/poll_guard_test.rs
@@ -8,11 +8,7 @@ mod util;
 #[test]
 fn changed_file() {
     let tmp = tempfile::tempdir().unwrap();
-    let mut repo = util::git_repo::GitRepo::new(tmp.path().to_path_buf());
-    repo.init();
-    repo.write_file("foo.txt");
-    repo.commit_all();
-
+    let mut repo = repo_and_file!(tmp, "foo.txt");
     let mut pg = PollGuard::new();
     assert!(!pg.dir_changed(repo.dir.as_path()));
 
@@ -25,11 +21,7 @@ fn changed_file() {
 #[test]
 fn branch_changed() {
     let tmp = tempfile::tempdir().unwrap();
-    let repo = util::git_repo::GitRepo::new(tmp.path().to_path_buf());
-    repo.init();
-    repo.write_file("foo.txt");
-    repo.commit_all();
-
+    let repo = repo_and_file!(tmp, "foo.txt");
     let mut pg = PollGuard::new();
     assert!(!pg.dir_changed(repo.dir.as_path()));
 
@@ -42,11 +34,7 @@ fn branch_changed() {
 #[test]
 fn file_changed_after_snapshot() {
     let tmp = tempfile::tempdir().unwrap();
-    let mut repo = util::git_repo::GitRepo::new(tmp.path().to_path_buf());
-    repo.init();
-    repo.write_file("foo.txt");
-    repo.commit_all();
-
+    let mut repo = repo_and_file!(tmp, "foo.txt");
     let mut pg = PollGuard::new();
     assert!(!pg.dir_changed(repo.dir.as_path()));
 

--- a/tests/poll_guard_test.rs
+++ b/tests/poll_guard_test.rs
@@ -1,0 +1,64 @@
+use dura::poll_guard::PollGuard;
+use dura::snapshots;
+use std::thread::sleep;
+use std::time::Duration;
+
+mod util;
+
+#[test]
+fn changed_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut repo = util::git_repo::GitRepo::new(tmp.path().to_path_buf());
+    repo.init();
+    repo.write_file("foo.txt");
+    repo.commit_all();
+
+    let mut pg = PollGuard::new();
+    assert_eq!(pg.dir_changed(repo.dir.as_path()), false);
+
+    sleep(Duration::from_secs_f64(1.5));
+    repo.change_file("foo.txt");
+    assert_eq!(pg.dir_changed(repo.dir.as_path()), true);
+}
+
+/// Changing a branch shouldn't trigger the slow process
+#[test]
+fn branch_changed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = util::git_repo::GitRepo::new(tmp.path().to_path_buf());
+    repo.init();
+    repo.write_file("foo.txt");
+    repo.commit_all();
+
+    let mut pg = PollGuard::new();
+    assert_eq!(pg.dir_changed(repo.dir.as_path()), false);
+
+    sleep(Duration::from_secs_f64(1.5));
+    repo.git(&["checkout", "-b", "new-branch"])
+        .expect("checkout failed");
+    assert_eq!(pg.dir_changed(repo.dir.as_path()), false);
+}
+
+#[test]
+fn file_changed_after_snapshot() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut repo = util::git_repo::GitRepo::new(tmp.path().to_path_buf());
+    repo.init();
+    repo.write_file("foo.txt");
+    repo.commit_all();
+
+    let mut pg = PollGuard::new();
+    assert_eq!(pg.dir_changed(repo.dir.as_path()), false);
+
+    sleep(Duration::from_secs_f64(1.5));
+    repo.change_file("foo.txt");
+    assert_eq!(pg.dir_changed(repo.dir.as_path()), true);
+
+    sleep(Duration::from_secs_f64(1.5));
+    snapshots::capture(repo.dir.as_path()).expect("snapshot failed");
+    assert_eq!(pg.dir_changed(repo.dir.as_path()), false);
+
+    sleep(Duration::from_secs_f64(1.5));
+    repo.change_file("foo.txt");
+    assert_eq!(pg.dir_changed(repo.dir.as_path()), true);
+}

--- a/tests/poll_guard_test.rs
+++ b/tests/poll_guard_test.rs
@@ -17,7 +17,14 @@ fn changed_file() {
     assert!(pg.dir_changed(repo.dir.as_path()));
 }
 
-/// Changing a branch shouldn't trigger the slow process
+/// Changing a branch still looks like a file change.
+///
+/// The reason is because `Repository::is_path_ignored` takes a ton of time,
+/// mostly in stat() calls trying to find the ignore file and git attributes.
+/// `PollGuard` is hit far too often to be able to use `Repository.is_path_ignored`.
+///
+/// We could ignore all files in `.git/`, but the name of that directory can change,
+/// and the flame graphs aren't showing a lot of time being used there.
 #[test]
 fn branch_changed() {
     let tmp = tempfile::tempdir().unwrap();
@@ -28,7 +35,7 @@ fn branch_changed() {
     sleep(Duration::from_secs_f64(1.5));
     repo.git(&["checkout", "-b", "new-branch"])
         .expect("checkout failed");
-    assert!(!pg.dir_changed(repo.dir.as_path()));
+    assert!(pg.dir_changed(repo.dir.as_path()));
 }
 
 #[test]

--- a/tests/snapshots_test.rs
+++ b/tests/snapshots_test.rs
@@ -10,11 +10,7 @@ extern crate serial_test;
 #[test]
 fn change_single_file() {
     let tmp = tempfile::tempdir().unwrap();
-    let mut repo = util::git_repo::GitRepo::new(tmp.path().to_path_buf());
-    repo.init();
-    repo.write_file("foo.txt");
-    repo.commit_all();
-
+    let mut repo = repo_and_file!(tmp, "foo.txt");
     repo.change_file("foo.txt");
     let status = snapshots::capture(repo.dir.as_path()).unwrap().unwrap();
 
@@ -26,11 +22,7 @@ fn change_single_file() {
 #[test]
 fn no_changes() {
     let tmp = tempfile::tempdir().unwrap();
-    let repo = util::git_repo::GitRepo::new(tmp.path().to_path_buf());
-    repo.init();
-    repo.write_file("foo.txt");
-    repo.commit_all();
-
+    let repo = repo_and_file!(tmp, "foo.txt");
     let status = snapshots::capture(repo.dir.as_path()).unwrap();
 
     assert_eq!(status, None);
@@ -40,12 +32,7 @@ fn no_changes() {
 #[test]
 fn during_merge_conflicts() {
     let tmp = tempfile::tempdir().unwrap();
-    let mut repo = util::git_repo::GitRepo::new(tmp.path().to_path_buf());
-    repo.init();
-
-    // parent commit
-    repo.write_file("foo.txt");
-    repo.commit_all();
+    let mut repo = repo_and_file!(tmp, "foo.txt");
 
     // branch1
     repo.change_file("foo.txt");

--- a/tests/util/daemon.rs
+++ b/tests/util/daemon.rs
@@ -36,11 +36,7 @@ impl Daemon {
     /// over the channel. It sends a None right before it quits, either due to an error or EOF.
     fn attach(stdout: ChildStdout, kill_sign: Arc<Mutex<i32>>) -> Receiver<Option<String>> {
         fn is_ignored(msg: &str) -> bool {
-            if msg.contains("Started serving with dura") {
-                true
-            } else {
-                false
-            }
+            msg.contains("Started serving with dura")
         }
         let (sender, receiver) = channel();
         thread::spawn(move || {

--- a/tests/util/macros.rs
+++ b/tests/util/macros.rs
@@ -1,0 +1,11 @@
+/// Create a Git repo with a single file and commit
+#[macro_export]
+macro_rules! repo_and_file {
+    ( $tmp:expr, $file_name:expr ) => {{
+        let repo = util::git_repo::GitRepo::new($tmp.path().to_path_buf());
+        repo.init();
+        repo.write_file($file_name);
+        repo.commit_all();
+        repo
+    }};
+}

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -4,3 +4,4 @@
 pub mod daemon;
 pub mod dura;
 pub mod git_repo;
+pub mod macros;


### PR DESCRIPTION
The current version performs a `git commit` on every repository every 5 seconds. If nothing changed, it simply has no effect. This strategy is eating up sometimes 10-20% of my CPU (on a poor dev machine), due to the massive amount of hashing needed to commit so many repositories.

This change creates an optimization by tracking file changed timestamps and comparing them against last commit timestamps. To do this, we have to traverse all files in each repository, which `git commit` is doing anyway. The big difference is that we only need to traverse to the inode (directory) for the file timestamp entries, so it should be significantly faster.

## Considered Design: `notify`
It has been suggested to use the `notify` crate to be notified of file changes. The trouble here was a global limit on file descriptors that can be watched, so you can't watch all files. I considered some machine learning appraches to guessing which files should be watched, but abandoned the approach because every strategy I could think of inolved a fallback to eactly what I'm doing here.

## Considered Design: SQLite
Use SQLite to remember timestamps of every file. This was needlessly complex because I only need to remember one timestamp - the most recent one. And more important, the last dura commit already stores it, so SQLite wasn't adding any value.

# Results
On the laptop where I was getting ~10% CPU utilization, it's now less that 0.1% (it doesn't register). There's a stark drop in the Activity Monitor graph after I installed the updated version.

<img width="178" alt="image" src="https://user-images.githubusercontent.com/437044/204149706-001187ae-fd97-4652-8dfa-de82df21bb2b.png">

