### PR TITLE
Do not allow to run dura as root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sudo",
  "tempfile",
  "tokio",
  "toml",
@@ -944,6 +945,16 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "sudo"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bd84d4c082e18e37fef52c0088e4407dabcef19d23a607fb4b5ee03b7d5b83"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ toml = "0.5.8"
 tracing = { version = "0.1.5"}
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 walkdir = "2.3.2"
+sudo = "0.6.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,11 @@ use tracing_subscriber::{EnvFilter, Registry};
 
 #[tokio::main]
 async fn main() {
+    if !check_if_user() {
+        eprintln!("Dura cannot be run as root, to avoid data corruption");
+        process::exit(1);
+    }
+
     let cwd = std::env::current_dir().expect("Failed to get current directory");
 
     let suffix = option_env!("DURA_VERSION_SUFFIX")
@@ -244,6 +249,16 @@ fn unwatch_dir(path: &std::path::Path) {
 
     config.set_unwatch(path);
     config.save();
+}
+
+#[cfg(all(unix))]
+fn check_if_user() -> bool {
+    sudo::check() != sudo::RunningAs::Root
+}
+
+#[cfg(target_os = "windows")]
+fn check_if_user() -> bool {
+    true
 }
 
 /// kills running dura poller


### PR DESCRIPTION
Simply checking the uid and euid to check if the user is root and just not checking on windows

(previous pr got removed because of discarding commit, sorry)